### PR TITLE
feat(prompt): improve text-to-block prompting (unified, anchored, block-safe)

### DIFF
--- a/apps/backend/src/runtime.mjs
+++ b/apps/backend/src/runtime.mjs
@@ -2,7 +2,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  buildTargetPromptExtras,
+  buildCorrectionInstruction,
+  buildSystemPrompt,
   buildUserPrompt,
   extractGeminiText,
   normaliseFeedback,
@@ -546,147 +547,6 @@ function withTimeout(promise, timeoutMs) {
   return wrapped;
 }
 
-const TARGET_CONFIGS = {
-  microbit: {
-    name: "micro:bit",
-    apis: [
-      "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), pause(ms)",
-      "input: onButtonPressed(Button.A/B/AB, handler), onGesture(Gesture.Shake/Tilt/..., handler), onPinPressed(TouchPin.P0/P1/P2, handler), buttonIsPressed(Button), temperature(), lightLevel(), acceleration(Dimension.X/Y/Z), compassHeading(), rotation(Rotation), magneticForce(Dimension), runningTime()",
-      "music: playTone(Note, BeatFraction), ringTone(freq), rest(BeatFraction), beat(BeatFraction), tempo(), setTempo(bpm), changeTempoBy(delta)",
-      "led: plot(x,y), unplot(x,y), toggle(x,y), point(x,y), brightness(), setBrightness(n), plotBarGraph(value, high), enable(on)",
-      "radio: sendNumber(n), sendString(s), sendValue(name, n), onReceivedNumber(handler), onReceivedString(handler), setGroup(id), setTransmitPower(n), setTransmitSerialNumber(on)",
-      "game: createSprite(x,y), .move(n), .turn(Direction,degrees), .ifOnEdgeBounce(), .isTouching(other), .isTouchingEdge(), addScore(n), score(), setScore(n), setLife(n), addLife(n), removeLife(n), gameOver(), startCountdown(ms)",
-      "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin,value), analogReadPin(AnalogPin), analogWritePin(AnalogPin,value), servoWritePin(AnalogPin,value), map(value,fromLow,fromHigh,toLow,toHigh), onPulsed(DigitalPin,PulseValue,handler), analogSetPitchPin(AnalogPin), analogPitch(freq,ms)",
-      "images: createImage(`...`), createBigImage(`...`), arrowImage(ArrowNames), iconImage(IconNames)",
-      "serial: writeLine(s), writeNumber(n), writeValue(name,value), readLine(), onDataReceived(delimiter,handler), redirect(tx,rx,rate)",
-      "control: inBackground(handler), reset(), waitMicros(us)",
-      "loops, logic, variables, math, functions, arrays, text (standard language built-ins)"
-    ].join("\n"),
-    example: [
-      "input.onButtonPressed(Button.A, function () {",
-      "    basic.showString(\"Hello\")",
-      "})",
-      "let count = 0",
-      "basic.forever(function () {",
-      "    count += 1",
-      "    basic.showNumber(count)",
-      "    basic.pause(1000)",
-      "})"
-    ].join("\n")
-  },
-  arcade: {
-    name: "Arcade",
-    apis: [
-      "sprites: create(img, SpriteKind), createProjectileFromSprite(img, sprite, vx, vy), onCreated(SpriteKind, handler), onDestroyed(SpriteKind, handler), onOverlap(SpriteKind, SpriteKind, handler), allOfKind(SpriteKind)",
-      "controller: moveSprite(sprite, vx, vy), controller.A.onEvent(ControllerButtonEvent, handler), controller.B.onEvent(ControllerButtonEvent, handler), dx(), dy()",
-      "scene: setBackgroundColor(color), setBackgroundImage(img), cameraFollowSprite(sprite), setTileMapLevel(tilemap), onHitWall(SpriteKind, handler), onOverlapTile(SpriteKind, tile, handler)",
-      "game: onUpdate(handler), onUpdateInterval(ms, handler), splash(title, subtitle?), over(win), reset()",
-      "info: score(), setScore(n), changeScoreBy(n), life(), setLife(n), changeLifeBy(n), startCountdown(s), onCountdownEnd(handler), onLifeZero(handler)",
-      "music: playTone(freq, ms), playMelody(melody, tempo), setVolume(vol)",
-      "effects: spray, fire, warm radial, cool radial, halo, fountain (applied via sprite.startEffect())",
-      "animation: runImageAnimation(sprite, frames, interval, loop), runMovementAnimation(sprite, path, interval, loop)"
-    ].join("\n"),
-    example: [
-      "let mySprite = sprites.create(img`",
-      "    . . . . . . . . . . . . . . . .",
-      "    . . . . . . . . . . . . . . . .",
-      "    . . . . . 7 7 7 7 7 . . . . . .",
-      "    . . . . 7 7 7 7 7 7 7 . . . . .",
-      "    . . . 7 7 7 7 7 7 7 7 7 . . . .",
-      "    . . . . 7 7 7 7 7 7 7 . . . . .",
-      "    . . . . . 7 7 7 7 7 . . . . . .",
-      "    . . . . . . . . . . . . . . . .",
-      "`, SpriteKind.Player)",
-      "controller.moveSprite(mySprite)",
-      "mySprite.setStayInScreen(true)"
-    ].join("\n")
-  },
-  maker: {
-    name: "Maker",
-    apis: [
-      "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin, value), analogReadPin(AnalogPin), analogWritePin(AnalogPin, value), servoWritePin(AnalogPin, value), map(value, fromLow, fromHigh, toLow, toHigh)",
-      "input: onButtonPressed(handler), buttonIsPressed(), temperature(), lightLevel()",
-      "loops: forever(handler), pause(ms)",
-      "music: playTone(freq, ms), ringTone(freq), rest(ms), setTempo(bpm)"
-    ].join("\n"),
-    example: [
-      "let on = false",
-      "loops.forever(function () {",
-      "    on = !(on)",
-      "    if (on) {",
-      "        pins.digitalWritePin(DigitalPin.P0, 1)",
-      "    } else {",
-      "        pins.digitalWritePin(DigitalPin.P0, 0)",
-      "    }",
-      "    loops.pause(500)",
-      "})"
-    ].join("\n")
-  }
-};
-
-function systemPromptFor(target) {
-  const targetKey = TARGET_CONFIGS[target] ? target : "microbit";
-  const config = TARGET_CONFIGS[targetKey];
-  const targetPromptExtras = buildTargetPromptExtras(targetKey);
-
-  return [
-    `You are a Microsoft MakeCode assistant for ${config.name}.`,
-    `Your ONLY job is to produce MakeCode Static TypeScript that the MakeCode editor can decompile into visual BLOCKS for ${config.name}. Every line you output must be representable as a block. If a language feature has no block equivalent, do not use it.`,
-    "",
-    "AVAILABLE APIs:",
-    config.apis,
-    ...targetPromptExtras,
-    "",
-    "BLOCK-COMPATIBLE PATTERNS (use these):",
-    "- Event handlers: input.onButtonPressed(Button.A, function () { })",
-    "- Forever loops: basic.forever(function () { })",
-    "- Variables with let: let x = 0",
-    "- Control flow: if/else, while, for (let i = 0; i < n; i++), for (let v of list)",
-    "- Random choice from a list: options._pickRandom()",
-    "- Named functions: function doSomething() { }",
-    "",
-    "BLOCK-SAFE REQUIREMENTS (hard):",
-    "- No grey JavaScript blocks: every line must map to editable blocks",
-    "- Every variable declaration must have an initializer (let x = ...)",
-    "- For loops must be exactly: for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++)",
-    "- Event registrations and function declarations must be top-level",
-    "- Do not use optional/default parameters in user-defined functions",
-    "- Do not return a value inside callbacks/event handlers",
-    "- Do not pass more arguments than a block signature supports",
-    "- In statements, assignment operators are limited to =, +=, -=",
-    "",
-    "AVOID (these won't decompile to blocks):",
-    "- Arrow functions (=>), ternary (? :), destructuring, spread/rest (...)",
-    "- const, var (use let for all variables)",
-    "- Template literals for strings (use \"string\" + variable, not `${}`). Exception: backtick image literals like img`...` and showLeds(`...`) ARE allowed — these are a special MakeCode compiler feature, not string templates.",
-    "- Optional chaining (?.), nullish coalescing (??)",
-    "- for...in loops",
-    "- import/export, async/await, yield, eval",
-    "- Classes, interfaces, type aliases, enums, generics in user code",
-    "- Higher-order array methods (map/filter/reduce/forEach)",
-    "- randint(...) (use list._pickRandom() for random selections)",
-    "- null, undefined, casts (as), bitwise operators (| & ^ << >> >>>), bitwise compound assignments",
-    "- setTimeout, setInterval, console, Promise",
-    "- Comments, markdown fences, prose after code",
-    "",
-    "RESPONSE FORMAT:",
-    "- Return ONLY a JSON object with this exact shape:",
-    "- {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript with \\\\n escapes\"}",
-    "- feedback must be an array of one or more short strings",
-    "- code must be MakeCode Static TypeScript encoded as a JSON string (use escaped \\n for new lines, no markdown fences)",
-    "- Straight quotes, ASCII only, function () { } handlers",
-    "- If PAGE_ERRORS are provided, treat them as failing diagnostics and prioritise resolving all of them",
-    "- If CONVERSION_DIALOG is provided, ensure the output converts from JavaScript back to Blocks in MakeCode",
-    "",
-    `TARGET SCOPE: Use ONLY ${config.name} APIs listed above. Never mix APIs from other targets.`,
-    "",
-    "EXAMPLE:",
-    config.example,
-    "",
-    `If unsure about an API, return a minimal working program for ${config.name}.`
-  ].join("\n");
-}
-
 function userPromptFor(request, currentCode, pageErrors, conversionDialog) {
   return buildUserPrompt({
     request,
@@ -776,7 +636,7 @@ async function callGemini(key, model, system, user, signal) {
 async function generateManaged({ target, request, currentCode, pageErrors, conversionDialog, provider, model }, runtimeConfig, providerConfig) {
   const selected = resolveProviderSelection(providerConfig || runtimeConfig.providerConfig, provider, model);
 
-  const system = systemPromptFor(target);
+  const system = buildSystemPrompt(target);
   const user = userPromptFor(request, currentCode || "", pageErrors || [], conversionDialog || null);
   const callProvider = async (systemPrompt) => withTimeout(async (signal) => {
     if (selected.provider === "openai") return callOpenAI(selected.key, selected.model, systemPrompt, user, signal);
@@ -804,9 +664,7 @@ async function generateManaged({ target, request, currentCode, pageErrors, conve
 
   for (let i = 0; i < runtimeConfig.validationRetries && result.code && result.code.trim() && result.validation && !result.validation.ok; i++) {
     const violations = result.validation.violations || [];
-    const extra = i === 0
-      ? ("Previous code used: " + violations.join(", ") + ". Remove ALL forbidden constructs and return fully Blocks-compatible code.")
-      : ("STRICT MODE: Output a smaller program that fully decompiles to Blocks. Absolutely no: " + violations.join(", ") + ".");
+    const extra = buildCorrectionInstruction(violations, target, { strict: i > 0 });
     result = await oneAttempt(extra, true);
   }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:bookmarklet:byok": "npm run check:compat-core && npm --prefix apps/bookmarklet run build -- --enable-byok",
     "sync:compat-core": "node scripts/sync-compat-core.mjs",
     "check:compat-core": "node scripts/sync-compat-core.mjs --check",
+    "test": "node --test",
     "dev:watch-reload": "node scripts/dev/watch-build-reload.mjs",
     "package": "npm run check:compat-core && npm run build && node scripts/package.mjs",
     "backend:start": "node apps/backend/src/server.mjs",

--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -7,6 +7,8 @@ export const SHARED_COMPAT_EXPORT_NAMES = [
   "parseModelOutput",
   "validateBlocksCompatibility",
   "buildTargetPromptExtras",
+  "buildSystemPrompt",
+  "buildCorrectionInstruction",
   "stubForTarget",
   "extractGeminiText"
 ];
@@ -798,6 +800,181 @@ export function buildTargetPromptExtras(target) {
   ];
 }
 
+// Per-target grounding shared by Managed and BYOK system prompts. Each entry
+// carries the API cheat sheet plus a worked request -> response example so the
+// model sees both the supported surface and the exact output contract.
+export const TARGET_API_CATALOG = {
+  microbit: {
+    name: "micro:bit",
+    apis: [
+      "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), onStart(handler), pause(ms)",
+      "input: onButtonPressed(Button.A/B/AB, handler), onGesture(Gesture.Shake/Tilt/..., handler), onPinPressed(TouchPin.P0/P1/P2, handler), buttonIsPressed(Button), temperature(), lightLevel(), acceleration(Dimension.X/Y/Z), compassHeading(), rotation(Rotation), magneticForce(Dimension), runningTime()",
+      "music: playTone(Note, BeatFraction), ringTone(freq), rest(BeatFraction), beat(BeatFraction), tempo(), setTempo(bpm), changeTempoBy(delta)",
+      "led: plot(x,y), unplot(x,y), toggle(x,y), point(x,y), brightness(), setBrightness(n), plotBarGraph(value, high), enable(on)",
+      "radio: sendNumber(n), sendString(s), sendValue(name, n), onReceivedNumber(handler), onReceivedString(handler), setGroup(id), setTransmitPower(n), setTransmitSerialNumber(on)",
+      "game: createSprite(x,y), .move(n), .turn(Direction,degrees), .ifOnEdgeBounce(), .isTouching(other), .isTouchingEdge(), addScore(n), score(), setScore(n), setLife(n), addLife(n), removeLife(n), gameOver(), startCountdown(ms)",
+      "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin,value), analogReadPin(AnalogPin), analogWritePin(AnalogPin,value), servoWritePin(AnalogPin,value), map(value,fromLow,fromHigh,toLow,toHigh), onPulsed(DigitalPin,PulseValue,handler), analogSetPitchPin(AnalogPin), analogPitch(freq,ms)",
+      "images: createImage(`...`), createBigImage(`...`), arrowImage(ArrowNames), iconImage(IconNames)",
+      "serial: writeLine(s), writeNumber(n), writeValue(name,value), readLine(), onDataReceived(delimiter,handler), redirect(tx,rx,rate)",
+      "control: inBackground(handler), reset(), waitMicros(us)",
+      "loops, logic, variables, math, functions, arrays, text (standard language built-ins)"
+    ].join("\n"),
+    request: "count up each time I press button A and show the number",
+    feedback: ["Press A to add one and show the running count."],
+    example: [
+      "let count = 0",
+      "input.onButtonPressed(Button.A, function () {",
+      "    count += 1",
+      "    basic.showNumber(count)",
+      "})"
+    ].join("\n")
+  },
+  arcade: {
+    name: "Arcade",
+    apis: [
+      "sprites: create(img, SpriteKind), createProjectileFromSprite(img, sprite, vx, vy), onCreated(SpriteKind, handler), onDestroyed(SpriteKind, handler), onOverlap(SpriteKind, SpriteKind, handler), allOfKind(SpriteKind)",
+      "controller: moveSprite(sprite, vx, vy), controller.A.onEvent(ControllerButtonEvent, handler), controller.B.onEvent(ControllerButtonEvent, handler), dx(), dy()",
+      "scene: setBackgroundColor(color), setBackgroundImage(img), cameraFollowSprite(sprite), setTileMapLevel(tilemap), onHitWall(SpriteKind, handler), onOverlapTile(SpriteKind, tile, handler)",
+      "game: onUpdate(handler), onUpdateInterval(ms, handler), splash(title, subtitle?), over(win), reset()",
+      "info: score(), setScore(n), changeScoreBy(n), life(), setLife(n), changeLifeBy(n), startCountdown(s), onCountdownEnd(handler), onLifeZero(handler)",
+      "music: playTone(freq, ms), playMelody(melody, tempo), setVolume(vol)",
+      "effects: spray, fire, warm radial, cool radial, halo, fountain (applied via sprite.startEffect())",
+      "animation: runImageAnimation(sprite, frames, interval, loop), runMovementAnimation(sprite, path, interval, loop)"
+    ].join("\n"),
+    request: "make a player sprite I can move with the controller",
+    feedback: ["Created a player sprite you can move with the D-pad."],
+    example: [
+      "let mySprite = sprites.create(img`",
+      "    . . . . . . . . . . . . . . . .",
+      "    . . . . . . . . . . . . . . . .",
+      "    . . . . . 7 7 7 7 7 . . . . . .",
+      "    . . . . 7 7 7 7 7 7 7 . . . . .",
+      "    . . . 7 7 7 7 7 7 7 7 7 . . . .",
+      "    . . . . 7 7 7 7 7 7 7 . . . . .",
+      "    . . . . . 7 7 7 7 7 . . . . . .",
+      "    . . . . . . . . . . . . . . . .",
+      "`, SpriteKind.Player)",
+      "controller.moveSprite(mySprite)",
+      "mySprite.setStayInScreen(true)"
+    ].join("\n")
+  },
+  maker: {
+    name: "Maker",
+    apis: [
+      "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin, value), analogReadPin(AnalogPin), analogWritePin(AnalogPin, value), servoWritePin(AnalogPin, value), map(value, fromLow, fromHigh, toLow, toHigh)",
+      "input: onButtonPressed(handler), buttonIsPressed(), temperature(), lightLevel()",
+      "loops: forever(handler), pause(ms)",
+      "music: playTone(freq, ms), ringTone(freq), rest(ms), setTempo(bpm)"
+    ].join("\n"),
+    request: "blink the LED on pin P0 on and off",
+    feedback: ["Toggles P0 every half second so the LED blinks."],
+    example: [
+      "let on = false",
+      "loops.forever(function () {",
+      "    on = !(on)",
+      "    if (on) {",
+      "        pins.digitalWritePin(DigitalPin.P0, 1)",
+      "    } else {",
+      "        pins.digitalWritePin(DigitalPin.P0, 0)",
+      "    }",
+      "    loops.pause(500)",
+      "})"
+    ].join("\n")
+  }
+};
+
+function resolveTargetConfig(target) {
+  return TARGET_API_CATALOG[target] || TARGET_API_CATALOG.microbit;
+}
+
+// Positive, affirmative guidance ("do this") attended first; the model anchors
+// on the patterns it should imitate before reading the forbidden list.
+const BLOCK_SAFE_DO_RULES = [
+  "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), game.onUpdate(function () { }).",
+  "Declare every variable with let and an initial value, e.g. let score = 0.",
+  "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
+  "Keep event registrations and function declarations at the top level, never nested inside another handler.",
+  "Pick a random item with options._pickRandom() from an array of choices.",
+  "Join strings with \"text\" + value, and pass function () { } for every handler.",
+  "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart)."
+];
+
+// Hard exclusions: each line removes a construct the MakeCode decompiler cannot
+// represent as a block. Kept tight so the list stays load-bearing, not decorative.
+const BLOCK_UNSAFE_RULES = [
+  "Arrow functions (=>), ternary (? :), destructuring, spread/rest (...).",
+  "const or var (always use let).",
+  "Template-string interpolation (`${ }`). Backtick image literals img`...`, showLeds(`...`) and createImage(`...`) ARE allowed: they are a MakeCode compiler feature, not string templates.",
+  "Optional chaining (?.), nullish coalescing (??), for...in loops.",
+  "import/export, async/await/Promise, yield, eval, classes, interfaces, type aliases, enums, generics.",
+  "Higher-order array methods (map/filter/reduce/forEach/find/some/every).",
+  "randint(...) (use options._pickRandom() instead).",
+  "null, undefined, casts (as), and bitwise operators (| & ^ << >> >>>) with their compound assignments.",
+  "setTimeout, setInterval, console, comments, markdown fences, or any prose outside the JSON.",
+  "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=."
+];
+
+const OUTPUT_FORMAT_RULES = [
+  "Return ONLY one compact JSON object: {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript with \\\\n escapes\"}.",
+  "feedback is an array of one or more short, friendly strings.",
+  "code is MakeCode Static TypeScript encoded as a JSON string: newlines as escaped \\n, straight quotes, ASCII only, no markdown fences, no comments.",
+  "If PAGE_ERRORS are provided, treat them as failing diagnostics and fix every one of them.",
+  "If CONVERSION_DIALOG is provided, rewrite the code so MakeCode can convert it back to Blocks."
+];
+
+function buildFewShotExample(config) {
+  const response = JSON.stringify({
+    feedback: Array.isArray(config.feedback) ? config.feedback : [],
+    code: config.example || ""
+  });
+  return "USER_REQUEST: " + String(config.request || "") + "\nRESPONSE: " + response;
+}
+
+// Shared system-prompt builder for both Managed and BYOK paths. Structured as
+// Identity -> Capabilities -> Constraints -> Format with the prime directive at
+// the top and a single load-bearing rule repeated at the very end, because
+// models attend most strongly to the first and last lines of a long prompt.
+export function buildSystemPrompt(target, options = {}) {
+  const { conversational = false } = options;
+  const targetKey = TARGET_API_CATALOG[target] ? target : "microbit";
+  const config = TARGET_API_CATALOG[targetKey];
+  const targetPromptExtras = buildTargetPromptExtras(targetKey);
+
+  const lines = [];
+
+  // 1. Identity + prime directive (front anchor)
+  lines.push(conversational
+    ? "ROLE: You are a friendly Microsoft MakeCode assistant helping a student build a " + config.name + " project. Be encouraging, brief, and conversational."
+    : "ROLE: You are a Microsoft MakeCode assistant for " + config.name + ".");
+  lines.push("PRIME DIRECTIVE: Output ONLY MakeCode Static TypeScript that the MakeCode decompiler converts to BLOCKS for " + config.name + " with ZERO errors. Every line must map to a block; if a feature has no block equivalent, do not use it.");
+
+  // 2. Capabilities (grounding)
+  lines.push("", "AVAILABLE APIS (use " + config.name + " APIs only, never mix in another target's APIs):", config.apis);
+  if (targetPromptExtras.length) lines.push(...targetPromptExtras);
+
+  // 3. Constraints (positive guidance first, then forbidden constructs)
+  lines.push("", "WRITE BLOCK-SAFE CODE:");
+  lines.push(...BLOCK_SAFE_DO_RULES.map((rule) => "- " + rule));
+  lines.push("", "NEVER USE (these break Blocks conversion):");
+  lines.push(...BLOCK_UNSAFE_RULES.map((rule) => "- " + rule));
+
+  if (conversational) {
+    lines.push("", "CONVERSATION: If RECENT_CHAT is provided, use only that recent context. Treat CURRENT_CODE as the source of truth for project state. If CURRENT_CODE is truncated, make conservative edits and preserve existing patterns.");
+  }
+
+  // 4. Output contract
+  lines.push("", "OUTPUT FORMAT:");
+  lines.push(...OUTPUT_FORMAT_RULES.map((rule) => "- " + rule));
+
+  // Few-shot demonstration of the full request -> response contract
+  lines.push("", "EXAMPLE (" + config.name + " request -> response):", buildFewShotExample(config));
+
+  // End anchor (recency): repeat the single rule that must always hold
+  lines.push("", "FINAL RULE: Reply with only the JSON object {\"feedback\":[...],\"code\":\"...\"} and no other text. If unsure, return a minimal program guaranteed to decompile to Blocks for " + config.name + ".");
+
+  return lines.join("\n");
+}
+
 export function validateBlocksCompatibility(code, target) {
   const rules = [
     { re: /=>/g, why: "arrow functions" },
@@ -921,6 +1098,56 @@ export function stubForTarget(target) {
     "    basic.showString(\"Hi\")",
     "})"
   ].join("\n");
+}
+
+// Maps validator findings to concrete, positively-framed corrective actions so a
+// retry tells the model how to fix the code rather than only what was wrong.
+const VIOLATION_FIX_HINTS = [
+  { match: /arrow function/i, hint: "replace => callbacks with function () { } handlers" },
+  { match: /template string/i, hint: "build strings with \"text\" + value instead of `${ }`" },
+  { match: /higher-order array/i, hint: "loop with for (let item of list) instead of map/filter/forEach" },
+  { match: /for-loop|for\.\.\.in/i, hint: "use for (let i = 0; i < limit; i++)" },
+  { match: /randint/i, hint: "use options._pickRandom() for random choices" },
+  { match: /without initializer/i, hint: "give every let an initial value, e.g. let x = 0" },
+  { match: /nested event|non-top-level/i, hint: "move event handlers and functions to the top level" },
+  { match: /enum member/i, hint: "use only valid enum members such as Button.A or IconNames.Heart" },
+  { match: /arity/i, hint: "match each block's exact argument count" },
+  { match: /Arcade APIs|micro:bit APIs|other target/i, hint: "use only APIs for the selected target" },
+  { match: /optional\/default parameters/i, hint: "remove optional or default parameters from your functions" },
+  { match: /assignment operators/i, hint: "use only =, += or -= in statements" },
+  { match: /bitwise/i, hint: "avoid bitwise operators (| & ^ << >>)" },
+  { match: /class|interface|type|generic/i, hint: "remove TypeScript classes, interfaces, types and generics" },
+  { match: /comment/i, hint: "remove all comments" },
+  { match: /non-ASCII/i, hint: "use plain ASCII characters and straight quotes" }
+];
+
+export function buildCorrectionInstruction(violations, target, options = {}) {
+  const { strict = false } = options;
+  const list = (Array.isArray(violations) ? violations : [])
+    .map((item) => String(item || "").trim())
+    .filter(Boolean);
+  const targetName = resolveTargetConfig(target).name;
+
+  const hints = [];
+  const seenHints = new Set();
+  for (const violation of list) {
+    for (const { match, hint } of VIOLATION_FIX_HINTS) {
+      if (match.test(violation) && !seenHints.has(hint)) {
+        seenHints.add(hint);
+        hints.push(hint);
+      }
+    }
+  }
+
+  const parts = [strict
+    ? "STRICT MODE: your previous code still will not decompile to Blocks for " + targetName + "."
+    : "Your previous code will not decompile to Blocks for " + targetName + "."];
+  if (list.length) parts.push("Problems: " + list.join(", ") + ".");
+  if (hints.length) parts.push("Fix by: " + hints.join("; ") + ".");
+  parts.push(strict
+    ? "Return a smaller program that uses only block-safe " + targetName + " constructs, as JSON only."
+    : "Return corrected, fully block-safe " + targetName + " code as JSON only.");
+  return parts.join(" ");
 }
 
 export function extractGeminiText(response) {

--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -337,6 +337,7 @@ const MICROBIT_CALL_SIGNATURES = [
   { call: "basic.showArrow", minArgs: 1, maxArgs: 2 },
   { call: "basic.clearScreen", minArgs: 0, maxArgs: 0 },
   { call: "basic.forever", minArgs: 1, maxArgs: 1 },
+  { call: "basic.onStart", minArgs: 1, maxArgs: 1 },
   { call: "basic.pause", minArgs: 1, maxArgs: 1 },
   { call: "input.onButtonPressed", minArgs: 2, maxArgs: 2 },
   { call: "input.onGesture", minArgs: 2, maxArgs: 2 },
@@ -887,17 +888,37 @@ function resolveTargetConfig(target) {
   return TARGET_API_CATALOG[target] || TARGET_API_CATALOG.microbit;
 }
 
-// Positive, affirmative guidance ("do this") attended first; the model anchors
-// on the patterns it should imitate before reading the forbidden list.
-const BLOCK_SAFE_DO_RULES = [
-  "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), game.onUpdate(function () { }).",
-  "Declare every variable with let and an initial value, e.g. let score = 0.",
-  "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
-  "Keep event registrations and function declarations at the top level, never nested inside another handler.",
-  "Pick a random item with options._pickRandom() from an array of choices.",
-  "Join strings with \"text\" + value, and pass function () { } for every handler.",
-  "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart)."
-];
+// Target-specific positive examples so each prompt never cites APIs from another
+// platform (e.g. Arcade must not see basic.forever or input.onButtonPressed).
+function buildBlockSafeDoRules(target) {
+  const targetKey = TARGET_API_CATALOG[target] ? target : "microbit";
+  const common = [
+    "Declare every variable with let and an initial value, e.g. let score = 0.",
+    "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
+    "Keep event registrations and function declarations at the top level, never nested inside another handler.",
+    "Pick a random item with options._pickRandom() from an array of choices.",
+    "Join strings with \"text\" + value, and pass function () { } for every handler."
+  ];
+  if (targetKey === "arcade") {
+    return [
+      "Use event handlers and loops, e.g. controller.A.onEvent(ControllerButtonEvent.Pressed, function () { }), game.onUpdate(function () { }).",
+      "Match each block's exact argument count and use only valid Arcade enums (e.g. SpriteKind.Player, ControllerButtonEvent.Pressed).",
+      ...common
+    ];
+  }
+  if (targetKey === "maker") {
+    return [
+      "Use event handlers and loops, e.g. input.onButtonPressed(function () { }), loops.forever(function () { }).",
+      "Match each block's exact argument count and use only valid Maker enums (e.g. DigitalPin.P0).",
+      ...common
+    ];
+  }
+  return [
+    "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), basic.onStart(function () { }).",
+    "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart).",
+    ...common
+  ];
+}
 
 // Hard exclusions: each line removes a construct the MakeCode decompiler cannot
 // represent as a block. Kept tight so the list stays load-bearing, not decorative.
@@ -954,7 +975,7 @@ export function buildSystemPrompt(target, options = {}) {
 
   // 3. Constraints (positive guidance first, then forbidden constructs)
   lines.push("", "WRITE BLOCK-SAFE CODE:");
-  lines.push(...BLOCK_SAFE_DO_RULES.map((rule) => "- " + rule));
+  lines.push(...buildBlockSafeDoRules(targetKey).map((rule) => "- " + rule));
   lines.push("", "NEVER USE (these break Blocks conversion):");
   lines.push(...BLOCK_UNSAFE_RULES.map((rule) => "- " + rule));
 
@@ -1000,7 +1021,7 @@ export function validateBlocksCompatibility(code, target) {
     /(^|[^|])\|([^|=]|$)/m,
     /(^|[^&])&([^&=]|$)/m
   ];
-  const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
+  const eventRegistrationRe = /\b(?:basic\.forever|basic\.onStart|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
   if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
     return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -38,6 +38,26 @@ test("system prompt grounds the model in target-specific APIs only", () => {
   assert.ok(!/onstart functions/i.test(microbit));
 });
 
+test("block-safe examples stay within each target's API surface", () => {
+  const microbit = buildSystemPrompt("microbit");
+  const arcade = buildSystemPrompt("arcade");
+  const maker = buildSystemPrompt("maker");
+  const blockSafe = (prompt) => {
+    const start = prompt.indexOf("WRITE BLOCK-SAFE CODE:");
+    const end = prompt.indexOf("NEVER USE");
+    return prompt.slice(start, end);
+  };
+  assert.ok(blockSafe(microbit).includes("input.onButtonPressed"));
+  assert.ok(blockSafe(microbit).includes("basic.onStart"));
+  assert.ok(!blockSafe(microbit).includes("game.onUpdate"));
+  assert.ok(blockSafe(arcade).includes("game.onUpdate"));
+  assert.ok(!blockSafe(arcade).includes("input.onButtonPressed"));
+  assert.ok(!blockSafe(arcade).includes("basic.forever"));
+  assert.ok(blockSafe(maker).includes("loops.forever"));
+  assert.ok(!blockSafe(maker).includes("game.onUpdate"));
+  assert.ok(!blockSafe(maker).includes("basic.forever"));
+});
+
 test("conversational option toggles chat guidance without changing the contract", () => {
   const managed = buildSystemPrompt("microbit");
   const byok = buildSystemPrompt("microbit", { conversational: true });
@@ -78,6 +98,19 @@ test("fallback stub is block-safe for its target", () => {
     const result = validateBlocksCompatibility(stubForTarget(target), target);
     assert.ok(result.ok, `${target} stub violations: ${result.violations.join(", ")}`);
   }
+});
+
+test("basic.onStart must be top-level on micro:bit", () => {
+  const nested = [
+    "input.onButtonPressed(Button.A, function () {",
+    "    basic.onStart(function () {",
+    "        basic.showString(\"Hi\")",
+    "    })",
+    "})"
+  ].join("\n");
+  const result = validateBlocksCompatibility(nested, "microbit");
+  assert.equal(result.ok, false);
+  assert.ok(result.violations.includes("nested event registration"));
 });
 
 test("correction instruction turns violations into actionable fixes", () => {

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  TARGET_API_CATALOG,
+  buildCorrectionInstruction,
+  buildSystemPrompt,
+  parseModelOutput,
+  stubForTarget,
+  validateBlocksCompatibility
+} from "./makecode-compat-core.mjs";
+
+const TARGETS = ["microbit", "arcade", "maker"];
+
+test("system prompt keeps the four-block skeleton with front and end anchors", () => {
+  for (const target of TARGETS) {
+    const prompt = buildSystemPrompt(target);
+    const config = TARGET_API_CATALOG[target];
+    assert.match(prompt, /^ROLE: /, `${target} prompt starts with ROLE`);
+    assert.ok(prompt.includes("PRIME DIRECTIVE:"), `${target} prompt has prime directive`);
+    assert.ok(prompt.includes("AVAILABLE APIS"), `${target} prompt lists APIs`);
+    assert.ok(prompt.includes("WRITE BLOCK-SAFE CODE:"), `${target} prompt has positive rules`);
+    assert.ok(prompt.includes("NEVER USE"), `${target} prompt has forbidden rules`);
+    assert.ok(prompt.includes("OUTPUT FORMAT:"), `${target} prompt has output contract`);
+    assert.ok(prompt.includes("EXAMPLE (" + config.name), `${target} prompt has a worked example`);
+    assert.match(prompt, /FINAL RULE: [\s\S]*$/, `${target} prompt ends with FINAL RULE anchor`);
+    assert.ok(prompt.includes(config.name), `${target} prompt names the target`);
+  }
+});
+
+test("system prompt grounds the model in target-specific APIs only", () => {
+  assert.ok(buildSystemPrompt("microbit").includes("basic:"));
+  assert.ok(buildSystemPrompt("arcade").includes("sprites:"));
+  assert.ok(buildSystemPrompt("maker").includes("loops:"));
+  // micro:bit on start is a real block and must not be forbidden anymore
+  const microbit = buildSystemPrompt("microbit");
+  assert.ok(microbit.includes("onStart(handler)"));
+  assert.ok(!/onstart functions/i.test(microbit));
+});
+
+test("conversational option toggles chat guidance without changing the contract", () => {
+  const managed = buildSystemPrompt("microbit");
+  const byok = buildSystemPrompt("microbit", { conversational: true });
+  assert.ok(!managed.includes("CONVERSATION:"));
+  assert.ok(byok.includes("CONVERSATION:"));
+  assert.ok(byok.includes("friendly"));
+  // Both still demand the same JSON contract
+  assert.ok(managed.includes("OUTPUT FORMAT:") && byok.includes("OUTPUT FORMAT:"));
+});
+
+test("unknown targets fall back to micro:bit", () => {
+  assert.equal(buildSystemPrompt("nonsense"), buildSystemPrompt("microbit"));
+});
+
+test("few-shot example code is block-safe for its target", () => {
+  for (const target of TARGETS) {
+    const { example } = TARGET_API_CATALOG[target];
+    const result = validateBlocksCompatibility(example, target);
+    assert.ok(result.ok, `${target} example violations: ${result.violations.join(", ")}`);
+  }
+});
+
+test("few-shot response parses as the model output contract and stays block-safe", () => {
+  for (const target of TARGETS) {
+    const prompt = buildSystemPrompt(target);
+    const match = prompt.match(/RESPONSE: (\{[\s\S]*?\})\n/);
+    assert.ok(match, `${target} prompt embeds a RESPONSE JSON object`);
+    const parsed = parseModelOutput(match[1]);
+    assert.ok(parsed.feedback.length >= 1, `${target} example has feedback`);
+    assert.ok(parsed.code.trim().length > 0, `${target} example has code`);
+    const result = validateBlocksCompatibility(parsed.code, target);
+    assert.ok(result.ok, `${target} parsed example violations: ${result.violations.join(", ")}`);
+  }
+});
+
+test("fallback stub is block-safe for its target", () => {
+  for (const target of TARGETS) {
+    const result = validateBlocksCompatibility(stubForTarget(target), target);
+    assert.ok(result.ok, `${target} stub violations: ${result.violations.join(", ")}`);
+  }
+});
+
+test("correction instruction turns violations into actionable fixes", () => {
+  const message = buildCorrectionInstruction(["arrow functions", "randint()"], "microbit");
+  assert.ok(message.includes("micro:bit"));
+  assert.ok(message.includes("function () { }"));
+  assert.ok(message.includes("options._pickRandom()"));
+  assert.ok(message.includes("Problems:"));
+  assert.ok(message.includes("Fix by:"));
+});
+
+test("strict correction instruction escalates and targets the right platform", () => {
+  const message = buildCorrectionInstruction(["Arcade APIs in micro:bit/Maker"], "arcade", { strict: true });
+  assert.ok(message.startsWith("STRICT MODE:"));
+  assert.ok(message.includes("Arcade"));
+  assert.ok(message.includes("only APIs for the selected target"));
+});
+
+test("correction instruction is safe with no violations", () => {
+  const message = buildCorrectionInstruction([], "maker");
+  assert.ok(message.includes("Maker"));
+  assert.ok(!message.includes("Problems:"));
+  assert.ok(message.length > 0);
+});

--- a/work.js
+++ b/work.js
@@ -1895,6 +1895,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     parseModelOutput,
     validateBlocksCompatibility,
     buildTargetPromptExtras,
+    buildSystemPrompt,
+    buildCorrectionInstruction,
     stubForTarget,
     extractGeminiText,
   } = (() => {
@@ -2685,6 +2687,181 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       ];
     }
 
+    // Per-target grounding shared by Managed and BYOK system prompts. Each entry
+    // carries the API cheat sheet plus a worked request -> response example so the
+    // model sees both the supported surface and the exact output contract.
+    const TARGET_API_CATALOG = {
+      microbit: {
+        name: "micro:bit",
+        apis: [
+          "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), onStart(handler), pause(ms)",
+          "input: onButtonPressed(Button.A/B/AB, handler), onGesture(Gesture.Shake/Tilt/..., handler), onPinPressed(TouchPin.P0/P1/P2, handler), buttonIsPressed(Button), temperature(), lightLevel(), acceleration(Dimension.X/Y/Z), compassHeading(), rotation(Rotation), magneticForce(Dimension), runningTime()",
+          "music: playTone(Note, BeatFraction), ringTone(freq), rest(BeatFraction), beat(BeatFraction), tempo(), setTempo(bpm), changeTempoBy(delta)",
+          "led: plot(x,y), unplot(x,y), toggle(x,y), point(x,y), brightness(), setBrightness(n), plotBarGraph(value, high), enable(on)",
+          "radio: sendNumber(n), sendString(s), sendValue(name, n), onReceivedNumber(handler), onReceivedString(handler), setGroup(id), setTransmitPower(n), setTransmitSerialNumber(on)",
+          "game: createSprite(x,y), .move(n), .turn(Direction,degrees), .ifOnEdgeBounce(), .isTouching(other), .isTouchingEdge(), addScore(n), score(), setScore(n), setLife(n), addLife(n), removeLife(n), gameOver(), startCountdown(ms)",
+          "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin,value), analogReadPin(AnalogPin), analogWritePin(AnalogPin,value), servoWritePin(AnalogPin,value), map(value,fromLow,fromHigh,toLow,toHigh), onPulsed(DigitalPin,PulseValue,handler), analogSetPitchPin(AnalogPin), analogPitch(freq,ms)",
+          "images: createImage(`...`), createBigImage(`...`), arrowImage(ArrowNames), iconImage(IconNames)",
+          "serial: writeLine(s), writeNumber(n), writeValue(name,value), readLine(), onDataReceived(delimiter,handler), redirect(tx,rx,rate)",
+          "control: inBackground(handler), reset(), waitMicros(us)",
+          "loops, logic, variables, math, functions, arrays, text (standard language built-ins)"
+        ].join("\n"),
+        request: "count up each time I press button A and show the number",
+        feedback: ["Press A to add one and show the running count."],
+        example: [
+          "let count = 0",
+          "input.onButtonPressed(Button.A, function () {",
+          "    count += 1",
+          "    basic.showNumber(count)",
+          "})"
+        ].join("\n")
+      },
+      arcade: {
+        name: "Arcade",
+        apis: [
+          "sprites: create(img, SpriteKind), createProjectileFromSprite(img, sprite, vx, vy), onCreated(SpriteKind, handler), onDestroyed(SpriteKind, handler), onOverlap(SpriteKind, SpriteKind, handler), allOfKind(SpriteKind)",
+          "controller: moveSprite(sprite, vx, vy), controller.A.onEvent(ControllerButtonEvent, handler), controller.B.onEvent(ControllerButtonEvent, handler), dx(), dy()",
+          "scene: setBackgroundColor(color), setBackgroundImage(img), cameraFollowSprite(sprite), setTileMapLevel(tilemap), onHitWall(SpriteKind, handler), onOverlapTile(SpriteKind, tile, handler)",
+          "game: onUpdate(handler), onUpdateInterval(ms, handler), splash(title, subtitle?), over(win), reset()",
+          "info: score(), setScore(n), changeScoreBy(n), life(), setLife(n), changeLifeBy(n), startCountdown(s), onCountdownEnd(handler), onLifeZero(handler)",
+          "music: playTone(freq, ms), playMelody(melody, tempo), setVolume(vol)",
+          "effects: spray, fire, warm radial, cool radial, halo, fountain (applied via sprite.startEffect())",
+          "animation: runImageAnimation(sprite, frames, interval, loop), runMovementAnimation(sprite, path, interval, loop)"
+        ].join("\n"),
+        request: "make a player sprite I can move with the controller",
+        feedback: ["Created a player sprite you can move with the D-pad."],
+        example: [
+          "let mySprite = sprites.create(img`",
+          "    . . . . . . . . . . . . . . . .",
+          "    . . . . . . . . . . . . . . . .",
+          "    . . . . . 7 7 7 7 7 . . . . . .",
+          "    . . . . 7 7 7 7 7 7 7 . . . . .",
+          "    . . . 7 7 7 7 7 7 7 7 7 . . . .",
+          "    . . . . 7 7 7 7 7 7 7 . . . . .",
+          "    . . . . . 7 7 7 7 7 . . . . . .",
+          "    . . . . . . . . . . . . . . . .",
+          "`, SpriteKind.Player)",
+          "controller.moveSprite(mySprite)",
+          "mySprite.setStayInScreen(true)"
+        ].join("\n")
+      },
+      maker: {
+        name: "Maker",
+        apis: [
+          "pins: digitalReadPin(DigitalPin), digitalWritePin(DigitalPin, value), analogReadPin(AnalogPin), analogWritePin(AnalogPin, value), servoWritePin(AnalogPin, value), map(value, fromLow, fromHigh, toLow, toHigh)",
+          "input: onButtonPressed(handler), buttonIsPressed(), temperature(), lightLevel()",
+          "loops: forever(handler), pause(ms)",
+          "music: playTone(freq, ms), ringTone(freq), rest(ms), setTempo(bpm)"
+        ].join("\n"),
+        request: "blink the LED on pin P0 on and off",
+        feedback: ["Toggles P0 every half second so the LED blinks."],
+        example: [
+          "let on = false",
+          "loops.forever(function () {",
+          "    on = !(on)",
+          "    if (on) {",
+          "        pins.digitalWritePin(DigitalPin.P0, 1)",
+          "    } else {",
+          "        pins.digitalWritePin(DigitalPin.P0, 0)",
+          "    }",
+          "    loops.pause(500)",
+          "})"
+        ].join("\n")
+      }
+    };
+
+    function resolveTargetConfig(target) {
+      return TARGET_API_CATALOG[target] || TARGET_API_CATALOG.microbit;
+    }
+
+    // Positive, affirmative guidance ("do this") attended first; the model anchors
+    // on the patterns it should imitate before reading the forbidden list.
+    const BLOCK_SAFE_DO_RULES = [
+      "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), game.onUpdate(function () { }).",
+      "Declare every variable with let and an initial value, e.g. let score = 0.",
+      "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
+      "Keep event registrations and function declarations at the top level, never nested inside another handler.",
+      "Pick a random item with options._pickRandom() from an array of choices.",
+      "Join strings with \"text\" + value, and pass function () { } for every handler.",
+      "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart)."
+    ];
+
+    // Hard exclusions: each line removes a construct the MakeCode decompiler cannot
+    // represent as a block. Kept tight so the list stays load-bearing, not decorative.
+    const BLOCK_UNSAFE_RULES = [
+      "Arrow functions (=>), ternary (? :), destructuring, spread/rest (...).",
+      "const or var (always use let).",
+      "Template-string interpolation (`${ }`). Backtick image literals img`...`, showLeds(`...`) and createImage(`...`) ARE allowed: they are a MakeCode compiler feature, not string templates.",
+      "Optional chaining (?.), nullish coalescing (??), for...in loops.",
+      "import/export, async/await/Promise, yield, eval, classes, interfaces, type aliases, enums, generics.",
+      "Higher-order array methods (map/filter/reduce/forEach/find/some/every).",
+      "randint(...) (use options._pickRandom() instead).",
+      "null, undefined, casts (as), and bitwise operators (| & ^ << >> >>>) with their compound assignments.",
+      "setTimeout, setInterval, console, comments, markdown fences, or any prose outside the JSON.",
+      "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=."
+    ];
+
+    const OUTPUT_FORMAT_RULES = [
+      "Return ONLY one compact JSON object: {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript with \\\\n escapes\"}.",
+      "feedback is an array of one or more short, friendly strings.",
+      "code is MakeCode Static TypeScript encoded as a JSON string: newlines as escaped \\n, straight quotes, ASCII only, no markdown fences, no comments.",
+      "If PAGE_ERRORS are provided, treat them as failing diagnostics and fix every one of them.",
+      "If CONVERSION_DIALOG is provided, rewrite the code so MakeCode can convert it back to Blocks."
+    ];
+
+    function buildFewShotExample(config) {
+      const response = JSON.stringify({
+        feedback: Array.isArray(config.feedback) ? config.feedback : [],
+        code: config.example || ""
+      });
+      return "USER_REQUEST: " + String(config.request || "") + "\nRESPONSE: " + response;
+    }
+
+    // Shared system-prompt builder for both Managed and BYOK paths. Structured as
+    // Identity -> Capabilities -> Constraints -> Format with the prime directive at
+    // the top and a single load-bearing rule repeated at the very end, because
+    // models attend most strongly to the first and last lines of a long prompt.
+    function buildSystemPrompt(target, options = {}) {
+      const { conversational = false } = options;
+      const targetKey = TARGET_API_CATALOG[target] ? target : "microbit";
+      const config = TARGET_API_CATALOG[targetKey];
+      const targetPromptExtras = buildTargetPromptExtras(targetKey);
+
+      const lines = [];
+
+      // 1. Identity + prime directive (front anchor)
+      lines.push(conversational
+        ? "ROLE: You are a friendly Microsoft MakeCode assistant helping a student build a " + config.name + " project. Be encouraging, brief, and conversational."
+        : "ROLE: You are a Microsoft MakeCode assistant for " + config.name + ".");
+      lines.push("PRIME DIRECTIVE: Output ONLY MakeCode Static TypeScript that the MakeCode decompiler converts to BLOCKS for " + config.name + " with ZERO errors. Every line must map to a block; if a feature has no block equivalent, do not use it.");
+
+      // 2. Capabilities (grounding)
+      lines.push("", "AVAILABLE APIS (use " + config.name + " APIs only, never mix in another target's APIs):", config.apis);
+      if (targetPromptExtras.length) lines.push(...targetPromptExtras);
+
+      // 3. Constraints (positive guidance first, then forbidden constructs)
+      lines.push("", "WRITE BLOCK-SAFE CODE:");
+      lines.push(...BLOCK_SAFE_DO_RULES.map((rule) => "- " + rule));
+      lines.push("", "NEVER USE (these break Blocks conversion):");
+      lines.push(...BLOCK_UNSAFE_RULES.map((rule) => "- " + rule));
+
+      if (conversational) {
+        lines.push("", "CONVERSATION: If RECENT_CHAT is provided, use only that recent context. Treat CURRENT_CODE as the source of truth for project state. If CURRENT_CODE is truncated, make conservative edits and preserve existing patterns.");
+      }
+
+      // 4. Output contract
+      lines.push("", "OUTPUT FORMAT:");
+      lines.push(...OUTPUT_FORMAT_RULES.map((rule) => "- " + rule));
+
+      // Few-shot demonstration of the full request -> response contract
+      lines.push("", "EXAMPLE (" + config.name + " request -> response):", buildFewShotExample(config));
+
+      // End anchor (recency): repeat the single rule that must always hold
+      lines.push("", "FINAL RULE: Reply with only the JSON object {\"feedback\":[...],\"code\":\"...\"} and no other text. If unsure, return a minimal program guaranteed to decompile to Blocks for " + config.name + ".");
+
+      return lines.join("\n");
+    }
+
     function validateBlocksCompatibility(code, target) {
       const rules = [
         { re: /=>/g, why: "arrow functions" },
@@ -2810,6 +2987,56 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       ].join("\n");
     }
 
+    // Maps validator findings to concrete, positively-framed corrective actions so a
+    // retry tells the model how to fix the code rather than only what was wrong.
+    const VIOLATION_FIX_HINTS = [
+      { match: /arrow function/i, hint: "replace => callbacks with function () { } handlers" },
+      { match: /template string/i, hint: "build strings with \"text\" + value instead of `${ }`" },
+      { match: /higher-order array/i, hint: "loop with for (let item of list) instead of map/filter/forEach" },
+      { match: /for-loop|for\.\.\.in/i, hint: "use for (let i = 0; i < limit; i++)" },
+      { match: /randint/i, hint: "use options._pickRandom() for random choices" },
+      { match: /without initializer/i, hint: "give every let an initial value, e.g. let x = 0" },
+      { match: /nested event|non-top-level/i, hint: "move event handlers and functions to the top level" },
+      { match: /enum member/i, hint: "use only valid enum members such as Button.A or IconNames.Heart" },
+      { match: /arity/i, hint: "match each block's exact argument count" },
+      { match: /Arcade APIs|micro:bit APIs|other target/i, hint: "use only APIs for the selected target" },
+      { match: /optional\/default parameters/i, hint: "remove optional or default parameters from your functions" },
+      { match: /assignment operators/i, hint: "use only =, += or -= in statements" },
+      { match: /bitwise/i, hint: "avoid bitwise operators (| & ^ << >>)" },
+      { match: /class|interface|type|generic/i, hint: "remove TypeScript classes, interfaces, types and generics" },
+      { match: /comment/i, hint: "remove all comments" },
+      { match: /non-ASCII/i, hint: "use plain ASCII characters and straight quotes" }
+    ];
+
+    function buildCorrectionInstruction(violations, target, options = {}) {
+      const { strict = false } = options;
+      const list = (Array.isArray(violations) ? violations : [])
+        .map((item) => String(item || "").trim())
+        .filter(Boolean);
+      const targetName = resolveTargetConfig(target).name;
+
+      const hints = [];
+      const seenHints = new Set();
+      for (const violation of list) {
+        for (const { match, hint } of VIOLATION_FIX_HINTS) {
+          if (match.test(violation) && !seenHints.has(hint)) {
+            seenHints.add(hint);
+            hints.push(hint);
+          }
+        }
+      }
+
+      const parts = [strict
+        ? "STRICT MODE: your previous code still will not decompile to Blocks for " + targetName + "."
+        : "Your previous code will not decompile to Blocks for " + targetName + "."];
+      if (list.length) parts.push("Problems: " + list.join(", ") + ".");
+      if (hints.length) parts.push("Fix by: " + hints.join("; ") + ".");
+      parts.push(strict
+        ? "Return a smaller program that uses only block-safe " + targetName + " constructs, as JSON only."
+        : "Return corrected, fully block-safe " + targetName + " code as JSON only.");
+      return parts.join(" ");
+    }
+
     function extractGeminiText(response) {
       try {
         if (!response) return "";
@@ -2839,6 +3066,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       parseModelOutput,
       validateBlocksCompatibility,
       buildTargetPromptExtras,
+      buildSystemPrompt,
+      buildCorrectionInstruction,
       stubForTarget,
       extractGeminiText,
     };
@@ -2848,31 +3077,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
   let BASE_TEMP = 0.1;
   let MAXTOK = 3072;
 
-  const sysFor = (target) => {
-    const { namespaceList, targetName } = resolvePromptTargetContext(target);
-    const targetPromptExtras = buildTargetPromptExtras(target);
-    return [
-      "ROLE: You are a friendly Microsoft MakeCode assistant helping a student build a " + targetName + " project. You are having a conversation – be helpful, brief, and encouraging.",
-      "HARD REQUIREMENT: Return ONLY Microsoft MakeCode Static JavaScript that the MakeCode decompiler can convert to BLOCKS for " + targetName + " with ZERO errors.",
-      "CONVERSATION CONTEXT: If RECENT_CHAT is provided, use only that recent context. Treat CURRENT_CODE as the source of truth for project state.",
-      "CONTEXT LIMITS: CURRENT_CODE may include a truncation note if the project is large. When truncated, make conservative edits and preserve existing patterns.",
-      "RESPONSE FORMAT (required): Return ONLY compact JSON with keys feedback and code.",
-      "FORMAT DETAILS: {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript with \\\\n escapes\"}.",
-      "FEEDBACK RULE: feedback must be an array with at least one short string.",
-      "CODE RULE: code must be MakeCode Static TypeScript encoded as a JSON string (use escaped \\n for new lines, no markdown fences).",
-      "NO COMMENTS inside the code.",
-      "ERROR FIXING: If PAGE_ERRORS are provided, treat them as failing diagnostics and prioritise resolving all of them in your output.",
-      "BLOCKS CONVERSION: If CONVERSION_DIALOG is provided, ensure the output can be converted from JavaScript back to Blocks in MakeCode.",
-      "ALLOWED APIS: " + namespaceList + ". Prefer event handlers and forever/update loops.",
-      ...targetPromptExtras,
-      "RANDOMNESS: For random choices, prefer list._pickRandom() from an array of options. Do NOT use randint(...).",
-      "BLOCK-SAFE REQUIREMENTS (hard): no grey JavaScript blocks; every variable declaration must have an initializer; for loops must be exactly for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); event registrations and function declarations must be top-level; no optional/default params in user-defined functions; callbacks/event handlers must not return a value; do not pass more arguments than block signatures support; statement assignment operators are limited to =, +=, -=.",
-      "FORBIDDEN IN OUTPUT: arrow functions (=>), classes, new constructors, async/await/Promise, import/export, template strings (`), higher-order array methods (map/filter/reduce/forEach/find/some/every), namespaces/modules, enums, interfaces, type aliases, generics, timers (setTimeout/setInterval), console calls, markdown, onstart functions, null, undefined, as-casts, bitwise operators (| & ^ << >> >>>) and bitwise compound assignments.",
-      "TARGET-SCOPE: Use ONLY APIs valid for " + targetName + ". Never mix Arcade APIs into micro:bit/Maker or vice versa.",
-      "STYLE: Straight quotes, ASCII only, use function () { } handlers.",
-      "IF UNSURE: Return a minimal program that is guaranteed to decompile to BLOCKS for " + targetName + ". Code only."
-    ].join("\n");
-  };
+  const sysFor = (target) => buildSystemPrompt(target, { conversational: true });
 
   const MAX_CURRENT_CODE_PROMPT_CHARS = 12000;
   const CURRENT_CODE_TRUNCATION_MARKER = "\n// ... CURRENT_CODE_TRUNCATED ...\n";
@@ -3059,12 +3264,12 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         if (!firstPass.code || !firstPass.code.trim()) return firstPass;
         if (firstPass.validation && firstPass.validation.ok) return firstPass;
         const violations = (firstPass.validation && firstPass.validation.violations) || [];
-        const extra = "Previous code used: " + violations.join(", ") + ". Remove ALL forbidden constructs. Use only " + (target === "arcade" ? "Arcade" : "micro:bit/Maker") + " APIs.";
+        const extra = buildCorrectionInstruction(violations, target, { strict: false });
         return oneAttempt(extra, true).then((secondPass) => {
           throwIfAborted(signal);
           if (secondPass.validation && secondPass.validation.ok) return secondPass;
           const secondViolations = (secondPass.validation && secondPass.validation.violations) || [];
-          const strictExtra = "STRICT MODE: Output a smaller program that fully decompiles to Blocks. Absolutely no: " + secondViolations.join(", ") + ".";
+          const strictExtra = buildCorrectionInstruction(secondViolations, target, { strict: true });
           return oneAttempt(strictExtra, true);
         });
       })

--- a/work.js
+++ b/work.js
@@ -2224,6 +2224,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       { call: "basic.showArrow", minArgs: 1, maxArgs: 2 },
       { call: "basic.clearScreen", minArgs: 0, maxArgs: 0 },
       { call: "basic.forever", minArgs: 1, maxArgs: 1 },
+      { call: "basic.onStart", minArgs: 1, maxArgs: 1 },
       { call: "basic.pause", minArgs: 1, maxArgs: 1 },
       { call: "input.onButtonPressed", minArgs: 2, maxArgs: 2 },
       { call: "input.onGesture", minArgs: 2, maxArgs: 2 },
@@ -2774,17 +2775,37 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       return TARGET_API_CATALOG[target] || TARGET_API_CATALOG.microbit;
     }
 
-    // Positive, affirmative guidance ("do this") attended first; the model anchors
-    // on the patterns it should imitate before reading the forbidden list.
-    const BLOCK_SAFE_DO_RULES = [
-      "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), game.onUpdate(function () { }).",
-      "Declare every variable with let and an initial value, e.g. let score = 0.",
-      "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
-      "Keep event registrations and function declarations at the top level, never nested inside another handler.",
-      "Pick a random item with options._pickRandom() from an array of choices.",
-      "Join strings with \"text\" + value, and pass function () { } for every handler.",
-      "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart)."
-    ];
+    // Target-specific positive examples so each prompt never cites APIs from another
+    // platform (e.g. Arcade must not see basic.forever or input.onButtonPressed).
+    function buildBlockSafeDoRules(target) {
+      const targetKey = TARGET_API_CATALOG[target] ? target : "microbit";
+      const common = [
+        "Declare every variable with let and an initial value, e.g. let score = 0.",
+        "Write for loops exactly as for (let i = 0; i < limit; i++) or for (let i = 0; i <= limit; i++); walk a list with for (let item of list).",
+        "Keep event registrations and function declarations at the top level, never nested inside another handler.",
+        "Pick a random item with options._pickRandom() from an array of choices.",
+        "Join strings with \"text\" + value, and pass function () { } for every handler."
+      ];
+      if (targetKey === "arcade") {
+        return [
+          "Use event handlers and loops, e.g. controller.A.onEvent(ControllerButtonEvent.Pressed, function () { }), game.onUpdate(function () { }).",
+          "Match each block's exact argument count and use only valid Arcade enums (e.g. SpriteKind.Player, ControllerButtonEvent.Pressed).",
+          ...common
+        ];
+      }
+      if (targetKey === "maker") {
+        return [
+          "Use event handlers and loops, e.g. input.onButtonPressed(function () { }), loops.forever(function () { }).",
+          "Match each block's exact argument count and use only valid Maker enums (e.g. DigitalPin.P0).",
+          ...common
+        ];
+      }
+      return [
+        "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), basic.onStart(function () { }).",
+        "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart).",
+        ...common
+      ];
+    }
 
     // Hard exclusions: each line removes a construct the MakeCode decompiler cannot
     // represent as a block. Kept tight so the list stays load-bearing, not decorative.
@@ -2841,7 +2862,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
 
       // 3. Constraints (positive guidance first, then forbidden constructs)
       lines.push("", "WRITE BLOCK-SAFE CODE:");
-      lines.push(...BLOCK_SAFE_DO_RULES.map((rule) => "- " + rule));
+      lines.push(...buildBlockSafeDoRules(targetKey).map((rule) => "- " + rule));
       lines.push("", "NEVER USE (these break Blocks conversion):");
       lines.push(...BLOCK_UNSAFE_RULES.map((rule) => "- " + rule));
 
@@ -2887,7 +2908,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         /(^|[^|])\|([^|=]|$)/m,
         /(^|[^&])&([^&=]|$)/m
       ];
-      const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
+      const eventRegistrationRe = /\b(?:basic\.forever|basic\.onStart|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
       if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
         return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The text-to-block conversion is driven by two **divergent** system prompts — one for BYOK (`work.js` `sysFor`) and a longer one for Managed (`runtime.mjs` `systemPromptFor`). They could drift, and the BYOK path only got a thin namespace list instead of the full API grounding. This PR applies recent agentic / harness / prompt-engineering best practices, scoped tightly to what MakeCode can actually decompile to Blocks.

Best practices applied (researched from current "harness vs prompt engineering" guidance):

- **Single source of truth / context parity** — one shared `buildSystemPrompt(target, { conversational })` builder in `shared/makecode-compat-core.mjs` powers both Managed and BYOK, so the two paths can no longer drift.
- **Four-block skeleton** — Identity → Capabilities → Constraints → Format, the structure production system prompts converge on.
- **Front + end anchoring (position bias)** — the one load-bearing rule (decompile to Blocks, JSON-only output) is stated as a `PRIME DIRECTIVE` at the top and repeated as a `FINAL RULE` at the very end, where models attend most.
- **Positive framing first** — a `WRITE BLOCK-SAFE CODE` do-list precedes the tightened `NEVER USE` forbidden-list.
- **Stronger grounding** — BYOK now gets the full per-target API cheat sheet (previously Managed-only), reducing hallucinated APIs.
- **Few-shot output contract** — each target embeds a worked `USER_REQUEST -> RESPONSE` example in the exact `{feedback, code}` JSON shape, so models copy both the decompile-safe style and the contract.
- **Reformulated retries (fix, don't just flag)** — new `buildCorrectionInstruction()` maps validator findings to concrete corrective actions (e.g. "replace => with function () { }", "use options._pickRandom()") instead of only listing what was wrong. Used by both retry loops.
- **Computational sensors over wording** — the existing `validateBlocksCompatibility` harness is preserved; new tests assert every prompt example and fallback stub passes it.

Also fixes a latent bug: the old BYOK prompt forbade "onstart functions" even though `basic.onStart` is a real Block (and the fallback stub uses it).

### Review follow-up (latest commit)

- **Target-scoped block-safe examples** — `WRITE BLOCK-SAFE CODE` examples are now per-target (micro:bit / Arcade / Maker) so prompts no longer cite APIs from other platforms.
- **`basic.onStart` harness alignment** — added to micro:bit call signatures and event-registration detection; nested `basic.onStart` is now rejected like other event handlers.

## Changes

- `shared/makecode-compat-core.mjs`: add `TARGET_API_CATALOG`, `buildSystemPrompt`, `buildCorrectionInstruction`, target-specific `buildBlockSafeDoRules`, and `basic.onStart` validation.
- `apps/backend/src/runtime.mjs`: use shared builder + correction hints; remove the duplicated `TARGET_CONFIGS` / `systemPromptFor`.
- `work.js`: `sysFor` delegates to the shared builder (conversational mode); retries use shared hints; embedded compat core re-synced.
- `shared/makecode-compat-core.test.mjs` + `npm test` script: sensors for prompt anchors, per-target API scoping, example/stub block-safety, `basic.onStart` top-level rule, and correction hints.

## Validation

- `node --test` — 15/15 pass (prompt sensors + existing runtime tests).
- `npm run check:compat-core` — embedded core in sync.
- `npm run build` — `dist/` rebuilt; new prompt present in `content-script.js`.

Note: not browser-verified in this environment (no Chrome/MCP). Worth a manual MakeCode smoke test (Managed + at least one BYOK provider) per `AGENTS.md` before merge.

## Possible follow-ups (not in this PR)

- Use provider-native structured output (OpenAI `response_format`, Gemini `responseMimeType`) to cut JSON parse failures — kept out here to avoid breaking arbitrary BYOK models.
- A small eval set of request→decompile-safe-code pairs to track prompt regressions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f17db-1ecc-73ec-8be8-db9ce50a6e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f17db-1ecc-73ec-8be8-db9ce50a6e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

