### PR TITLE
feat: set up Cursor Cloud agent environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,47 @@
+# Cursor Cloud Agent environment for the Vibbit monorepo.
+# Cursor checks out the repository at runtime; do not COPY the project tree.
+
+FROM node:22-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    sudo \
+    # node-canvas native build/runtime libraries
+    build-essential \
+    pkg-config \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    # Playwright Chromium runtime libraries
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdrm2 \
+    libgbm1 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxshmfence1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
+    && usermod -aG sudo ubuntu \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+
+USER ubuntu
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://cursor.com/schemas/environment.schema.json",
+  "name": "Vibbit",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": "npm ci && npm run audit:install"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,53 @@ Secrets for live audits:
 
 - keep in `.env.audit` (gitignored) or process environment variables.
 - template: `.env.audit.example`.
+
+## Cursor Cloud specific instructions
+
+Cloud agent environment configuration lives in `.cursor/environment.json` and `.cursor/Dockerfile`. On startup, Cursor runs `npm ci && npm run audit:install` to hydrate Node dependencies and Playwright Chromium.
+
+### Quick verification after changes
+
+```bash
+npm run check:compat-core
+npm run build
+npm run package
+npm run audit:smoke
+```
+
+Expected artefacts:
+
+- `dist/content-script.js`
+- `dist/manifest.json`
+- `artifacts/vibbit-extension.zip`
+- `output/playwright/audits/<run>/REPORT.md` plus screenshots
+
+### Backend smoke checks
+
+The managed backend starts without a checked-in `.env` file:
+
+```bash
+npm run backend:start
+curl http://localhost:8787/healthz
+```
+
+Use a tmux session for long-running processes such as the backend dev server.
+
+### Cloud vs local browser validation
+
+Playwright smoke audits are the primary automated verification path in cloud agents. They inject the runtime into MakeCode and exercise managed/BYOK UI flows without a full Chrome extension install.
+
+The DevTools MCP + unpacked-extension loop in the sections above is for local desktop testing. In cloud agents, prefer `npm run audit:smoke` (and `npm run audit:live` when secrets are configured) instead of loading `dist/` in Chrome.
+
+### Secrets for live audits
+
+Add these as Cursor Cloud secrets (or export them in the agent shell) when running `npm run audit:live`:
+
+- `AUDIT_BYOK_OPENAI_KEY` / `AUDIT_BYOK_GEMINI_KEY` / `AUDIT_BYOK_OPENROUTER_KEY` (as needed)
+- `AUDIT_MANAGED_BACKEND` / `AUDIT_MANAGED_APP_TOKEN` (for managed live checks)
+
+See `.env.audit.example` for the full list.
+
+### Provider keys for backend live tests
+
+For end-to-end managed generation against a local backend, configure provider keys via `apps/backend/.env` (copy from `apps/backend/.env.example`) or the `/admin` panel after start.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds committed Cursor Cloud agent environment configuration so cloud agents start with the dependencies and tooling needed to build, package, and smoke-test Vibbit.

## Changes

- **`.cursor/environment.json`** — defines the cloud environment install hook (`npm ci && npm run audit:install`).
- **`.cursor/Dockerfile`** — Debian-based image with Node 22, `git`/`sudo`, `node-canvas` native libraries, and Playwright Chromium runtime dependencies.
- **`AGENTS.md`** — new "Cursor Cloud specific instructions" section covering verification commands, backend smoke checks, cloud vs local browser validation, and required secrets for live audits.

## Verification

Validated in the current cloud VM:

- `npm ci`
- `npm run build`
- `npm run package`
- `npm run audit:install`
- `npm run audit:smoke` (UI flow passes; one pre-existing backend prompt guardrail check still fails)
- `npm run backend:start` + `curl http://localhost:8787/healthz`

## Follow-up (manual)

After merging, open the [Cursor Cloud Agents dashboard](https://cursor.com/dashboard?tab=cloud-agents) and confirm the environment builds from `.cursor/environment.json`. Add optional secrets for `npm run audit:live` (see `.env.audit.example`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f17f2-82ea-7d36-bf6d-3aa25fdd7a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f17f2-82ea-7d36-bf6d-3aa25fdd7a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

