### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,14 @@ Secrets for live audits:
 
 - keep in `.env.audit` (gitignored) or process environment variables.
 - template: `.env.audit.example`.
+
+## Cursor Cloud specific instructions
+
+The cloud VM is headless Linux (no GUI Chrome). Dependencies are pre-installed by the startup update script (`npm install`); the `canvas` native dependency installs from a prebuilt binary, so no system libraries are required. Build/test commands are documented above and run as-is.
+
+Service/runtime notes for this environment:
+
+- **Managed backend** (`npm run backend:start`) does NOT auto-load `apps/backend/.env`; it reads only `process.env`. It works with zero config because classroom mode and auto class-code generation are on by default. On startup it logs the student share line (URL + class code) and the admin URL with token — read those from stdout to drive `POST /vibbit/connect` and `/admin`.
+- **Real LLM generation** (managed `/vibbit/generate` or BYOK) needs provider API keys (OpenAI/Gemini/OpenRouter), set via env vars or the `/admin` panel. Without keys you can still verify the full UI flow with `npm run audit:smoke`, which mocks the LLM responses.
+- **Playwright smoke audit** (`npm run audit:smoke`) needs Chromium first: run `npx playwright install chromium` (i.e. `npm run audit:install`). It loads the live `https://makecode.microbit.org/`, so it requires outbound internet. It is the best headless end-to-end check since GUI Chrome / the unpacked-extension and `dev:watch-reload` loops described above are not usable in the cloud VM.
+- Known pre-existing audit gap: smoke check `03b Backend prompt micro:bit guardrails` currently FAILs because `apps/backend/src/runtime.mjs` lacks the `MICRO:BIT BUILT-IN ICON/ENUM RULES` / `MICRO:BIT BLOCKS-TEST STYLE EXAMPLES` strings that `work.js` has. All UI generation checks pass — do not assume a code change broke the audit if only `03b` fails.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Vibbit monorepo (Chrome extension + managed backend + bookmarklet builder) in the Cursor Cloud headless Linux VM, and records durable cloud-specific learnings in `AGENTS.md`.

No application code was changed — only a `## Cursor Cloud specific instructions` section was appended to `AGENTS.md`.

## Environment verification

- `npm install` — installs root deps; `canvas` resolves from a prebuilt binary (no system libs needed).
- `npm run build` + `npm run package` — produces `dist/content-script.js`, `dist/manifest.json`, `artifacts/vibbit-extension.zip`.
- `npm test` (`node --test`) — 15/15 pass.
- `npm run check:compat-core` — in sync.
- `npm run backend:start` — managed backend on `http://localhost:8787`; verified `/healthz`, `/vibbit/config`, and classroom `POST /vibbit/connect` (returns a session token).
- `npm run audit:smoke` — injects `work.js` into live MakeCode and exercises managed + BYOK generation end-to-end. 13/14 checks pass; the only failure (`03b`) is a pre-existing backend prompt-string gap unrelated to setup.

## Hello-world demonstration

Both managed and BYOK generation flows inject code into a real MakeCode page ("Code applied to MakeCode"):

[Vibbit panel in MakeCode](https://cursor.com/agents/bc-36728172-f8a1-4d56-97c6-5936ef1eb457/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvibbit_panel_makecode.png)
[Managed-mode generation applied](https://cursor.com/agents/bc-36728172-f8a1-4d56-97c6-5936ef1eb457/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvibbit_managed_generation.png)
[BYOK-mode generation applied](https://cursor.com/agents/bc-36728172-f8a1-4d56-97c6-5936ef1eb457/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvibbit_byok_generation.png)

## Notes

- Update script: `npm install` (minimal, idempotent).
- The Chromium download for the optional Playwright audit (`npm run audit:install`) is documented in `AGENTS.md` rather than the update script, to keep startup reliable.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36728172-f8a1-4d56-97c6-5936ef1eb457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36728172-f8a1-4d56-97c6-5936ef1eb457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

