### PR TITLE
feat(generate): retry with the failed programme in the transcript

### DIFF
--- a/apps/backend/src/openai-compat.mjs
+++ b/apps/backend/src/openai-compat.mjs
@@ -10,12 +10,26 @@ function joinChatCompletionsUrl(baseUrl) {
   return `${raw}/chat/completions`;
 }
 
+function transcriptOrPair(messages, system, user) {
+  if (Array.isArray(messages) && messages.length) {
+    return messages.map((item) => ({
+      role: item && item.role ? String(item.role) : "user",
+      content: item && item.content != null ? String(item.content) : ""
+    }));
+  }
+  return [
+    { role: "system", content: String(system || "") },
+    { role: "user", content: String(user || "") }
+  ];
+}
+
 export async function callOpenAICompatible({
   apiKey,
   baseUrl,
   model,
   system,
   user,
+  messages,
   signal,
   temperature = 0.1,
   maxTokens = 3072,
@@ -29,10 +43,7 @@ export async function callOpenAICompatible({
   const body = {
     model: String(model || "").trim() || "gpt-4o-mini",
     max_tokens: maxTokens,
-    messages: [
-      { role: "system", content: String(system || "") },
-      { role: "user", content: String(user || "") }
-    ]
+    messages: transcriptOrPair(messages, system, user)
   };
   if (!/(?:^|\/)gpt-5\.6-luna$/i.test(body.model)) body.temperature = temperature;
   if (reasoning && typeof reasoning === "object") body.reasoning = reasoning;
@@ -74,6 +85,7 @@ export async function callOpenAIResponsesCompatible({
   model,
   system,
   user,
+  messages,
   signal,
   temperature = 0.1,
   maxTokens = 3072,
@@ -86,10 +98,7 @@ export async function callOpenAIResponsesCompatible({
   const body = {
     model: String(model || "").trim(),
     max_output_tokens: maxTokens,
-    input: [
-      { role: "system", content: String(system || "") },
-      { role: "user", content: String(user || "") }
-    ]
+    input: transcriptOrPair(messages, system, user)
   };
   if (!/^gpt-/i.test(body.model)) body.temperature = temperature;
 

--- a/apps/backend/src/provider-registry.mjs
+++ b/apps/backend/src/provider-registry.mjs
@@ -1,3 +1,4 @@
+import { serializeTranscript } from "../../../shared/makecode-compat-core.mjs";
 import { callOpenAICompatible, callOpenAIResponsesCompatible } from "./openai-compat.mjs";
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -127,6 +128,7 @@ export async function callManagedProvider({
   model,
   system,
   user,
+  messages,
   signal,
   customBaseUrl = "",
   temperature = 0.1,
@@ -144,8 +146,11 @@ export async function callManagedProvider({
 
   if (selectedProvider === "gemini") {
     const url = `${GEMINI_API_ROOT}/models/${encodeURIComponent(selectedModel)}:generateContent`;
+    const flattened = Array.isArray(messages) && messages.length
+      ? serializeTranscript(messages)
+      : { system, user };
     const body = {
-      contents: [{ role: "user", parts: [{ text: `${String(system || "")}\n\n${String(user || "")}` }] }],
+      contents: [{ role: "user", parts: [{ text: `${String(flattened.system || "")}\n\n${String(flattened.user || "")}` }] }],
       generationConfig: {
         temperature,
         maxOutputTokens: maxTokens
@@ -182,6 +187,7 @@ export async function callManagedProvider({
       model: openCodeTarget ? openCodeTarget.model : selectedModel,
       system,
       user,
+      messages,
       signal,
       temperature: selectedTemperature,
       maxTokens,
@@ -195,6 +201,7 @@ export async function callManagedProvider({
     model: openCodeTarget ? openCodeTarget.model : selectedModel,
     system,
     user,
+    messages,
     signal,
     temperature: selectedTemperature,
     maxTokens,

--- a/apps/backend/src/provider-registry.test.mjs
+++ b/apps/backend/src/provider-registry.test.mjs
@@ -191,3 +191,31 @@ test("callManagedProvider uses OpenRouter GPT-5.6 Luna without temperature", asy
   assert.equal(capturedBody.model, "openai/gpt-5.6-luna");
   assert.equal(capturedBody.temperature, undefined);
 });
+
+test("callManagedProvider flattens a transcript for Gemini", async () => {
+  let capturedBody = null;
+  await callManagedProvider({
+    provider: "gemini",
+    apiKey: "gem-key",
+    model: "gemini-2.5-flash",
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "first" },
+      { role: "assistant", content: "() => {}" },
+      { role: "user", content: "<<<FAILED_ATTEMPT>>>\n() => {}" }
+    ],
+    fetchImpl: async (_url, init) => {
+      capturedBody = JSON.parse(init.body);
+      return new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }]
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+  const text = capturedBody.contents[0].parts[0].text;
+  assert.match(text, /<<<USER>>>/);
+  assert.match(text, /<<<ASSISTANT>>>/);
+  assert.match(text, /FAILED_ATTEMPT/);
+});

--- a/apps/backend/src/runtime.mjs
+++ b/apps/backend/src/runtime.mjs
@@ -2,13 +2,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  buildCorrectionInstruction,
   buildSystemPrompt,
   buildUserPrompt,
   normaliseFeedback,
-  parseModelOutput,
-  stubForTarget,
-  validateBlocksCompatibility
+  runGenerationLoop,
+  serializeTranscript
 } from "../../../shared/makecode-compat-core.mjs";
 import {
   joinHtmlResponse,
@@ -39,6 +37,10 @@ const MAX_JSON_BYTES = 256 * 1024;
 const MAX_REQUEST_CHARS = 4000;
 const MAX_CURRENT_CODE_CHARS = 50000;
 const MAX_PAGE_ERROR_CHARS = 500;
+const MAX_RECENT_CHAT_TURNS = 4;
+const MAX_RECENT_CHAT_CHARS = 400;
+const MAX_ORACLE_MISS_REASON_CHARS = 220;
+const MAX_ORACLE_MISS_GREY_BLOCKS = 32;
 const MAX_UPSTREAM_ATTEMPTS = 3;
 const CLASS_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ";
 const CLASS_CODE_LENGTH = 10;
@@ -639,17 +641,18 @@ function withTimeout(promise, timeoutMs) {
   return wrapped;
 }
 
-function userPromptFor(request, currentCode, pageErrors, conversionDialog) {
+function userPromptFor(request, currentCode, pageErrors, conversionDialog, recentChat) {
   return buildUserPrompt({
     request,
     currentCode,
     pageErrors,
-    conversionDialog
+    conversionDialog,
+    recentChat
   });
 }
 
 async function generateManaged(
-  { target, request, currentCode, pageErrors, conversionDialog, provider, model },
+  { target, request, currentCode, pageErrors, conversionDialog, provider, model, recentChat },
   runtimeConfig,
   providerConfig,
   { onUpstreamAttempt, outboundUrlPolicy } = {}
@@ -661,8 +664,14 @@ async function generateManaged(
     : "";
 
   const system = buildSystemPrompt(target);
-  const user = userPromptFor(request, currentCode || "", pageErrors || [], conversionDialog || null);
-  let upstreamAttempts = 0;
+  const user = userPromptFor(
+    request,
+    currentCode || "",
+    pageErrors || [],
+    conversionDialog || null,
+    recentChat || []
+  );
+  let providerCalls = 0;
   const maxAttempts = Math.min(
     MAX_UPSTREAM_ATTEMPTS,
     1 + (runtimeConfig.emptyRetries || 0) + (runtimeConfig.validationRetries || 0)
@@ -672,86 +681,53 @@ async function generateManaged(
     ? (url, init) => outboundUrlPolicy.fetchSafe(url, init, { purpose: "managed provider endpoint" })
     : fetch;
 
-  const callProvider = async (systemPrompt) => {
-    if (upstreamAttempts >= maxAttempts) {
-      throw new Error("Upstream attempt limit reached");
-    }
-    upstreamAttempts += 1;
-    try {
-      const raw = await withTimeout(async (signal) => {
-        return callManagedProvider({
-          provider: selected.provider,
-          apiKey: selected.key,
-          model: selected.model,
-          system: systemPrompt,
-          user,
-          signal,
-          customBaseUrl: providerBaseUrl,
-          fetchImpl
-        });
-      }, runtimeConfig.requestTimeoutMs);
-      if (typeof onUpstreamAttempt === "function") {
-        await onUpstreamAttempt({ success: true, attempt: upstreamAttempts });
+  const result = await runGenerationLoop({
+    target,
+    systemPrompt: system,
+    initialUserPrompt: user,
+    emptyRetries: runtimeConfig.emptyRetries || 0,
+    validationRetries: runtimeConfig.validationRetries || 0,
+    maxAttempts,
+    callModel: async (messages) => {
+      if (providerCalls >= maxAttempts) {
+        throw new Error("Upstream attempt limit reached");
       }
-      return raw;
-    } catch (error) {
-      if (typeof onUpstreamAttempt === "function") {
-        await onUpstreamAttempt({ success: false, attempt: upstreamAttempts, error });
+      providerCalls += 1;
+      try {
+        const raw = await withTimeout(async (signal) => {
+          const flat = serializeTranscript(messages);
+          return callManagedProvider({
+            provider: selected.provider,
+            apiKey: selected.key,
+            model: selected.model,
+            messages,
+            system: flat.system,
+            user: flat.user,
+            signal,
+            customBaseUrl: providerBaseUrl,
+            fetchImpl
+          });
+        }, runtimeConfig.requestTimeoutMs);
+        if (typeof onUpstreamAttempt === "function") {
+          await onUpstreamAttempt({ success: true, attempt: providerCalls });
+        }
+        return raw;
+      } catch (error) {
+        if (typeof onUpstreamAttempt === "function") {
+          await onUpstreamAttempt({ success: false, attempt: providerCalls, error });
+        }
+        throw error;
       }
-      throw error;
     }
-  };
-
-  const oneAttempt = async (extraSystem, insistOnlyCode) => {
-    const prompt = system
-      + (extraSystem ? ("\n" + extraSystem) : "")
-      + (insistOnlyCode ? "\nMANDATE: Output only compact JSON with keys feedback (array) and code (string). No prose." : "");
-    const raw = await callProvider(prompt);
-    const parsed = parseModelOutput(raw);
-    const code = parsed.code;
-    const validation = code ? validateBlocksCompatibility(code, target) : { ok: false, violations: ["empty output"] };
-    return { code, feedback: parsed.feedback, validation };
-  };
-
-  let result = await oneAttempt("", false);
-
-  for (let i = 0; i < runtimeConfig.emptyRetries && upstreamAttempts < maxAttempts && (!result.code || !result.code.trim()); i++) {
-    result = await oneAttempt("Your last message had empty code. Return valid JSON only with feedback[] and code string.", true);
-  }
-
-  for (let i = 0; i < runtimeConfig.validationRetries && upstreamAttempts < maxAttempts && result.code && result.code.trim() && result.validation && !result.validation.ok; i++) {
-    const violations = result.validation.violations || [];
-    const extra = buildCorrectionInstruction(violations, target, { strict: i > 0 });
-    result = await oneAttempt(extra, true);
-  }
-
-  if (!result.code || !result.code.trim()) {
-    return {
-      code: stubForTarget(target),
-      feedback: normaliseFeedback(
-        [...(result.feedback || []), "Model returned no code; provided fallback stub."],
-        DEFAULT_FEEDBACK
-      ),
-      upstreamAttempts
-    };
-  }
-
-  if (!result.validation || !result.validation.ok) {
-    const violations = (result.validation && result.validation.violations) || [];
-    return {
-      code: stubForTarget(target),
-      feedback: normaliseFeedback(
-        [...(result.feedback || []), "Validation fallback: " + (violations.join(", ") || "unknown compatibility issue")],
-        DEFAULT_FEEDBACK
-      ),
-      upstreamAttempts
-    };
-  }
+  });
 
   return {
     code: result.code,
     feedback: normaliseFeedback(result.feedback, DEFAULT_FEEDBACK),
-    upstreamAttempts
+    validation: result.validation,
+    upstreamAttempts: result.upstreamAttempts,
+    outcome: result.outcome,
+    attempts: result.attempts
   };
 }
 
@@ -759,6 +735,32 @@ function extractBearerToken(headerValue) {
   if (!headerValue) return "";
   const match = String(headerValue).match(/^Bearer\s+(.+)$/i);
   return match ? match[1] : "";
+}
+
+function sanitiseRecentChat(raw) {
+  if (!Array.isArray(raw)) return [];
+  const turns = [];
+  for (const item of raw) {
+    if (turns.length >= MAX_RECENT_CHAT_TURNS) break;
+    if (!item || typeof item !== "object") continue;
+    const role = item.role === "assistant" ? "assistant" : (item.role === "user" ? "user" : "");
+    if (!role) continue;
+    const text = String(item.content || item.notes || "").replace(/\s+/g, " ").trim().slice(0, MAX_RECENT_CHAT_CHARS);
+    if (!text) continue;
+    if (role === "user") turns.push({ role, content: text });
+    else turns.push({ role, notes: text });
+  }
+  return turns;
+}
+
+function sanitiseOracleMissPayload(payload) {
+  const source = payload && typeof payload === "object" ? payload : {};
+  const reason = String(source.reason || "").replace(/\s+/g, " ").trim().slice(0, MAX_ORACLE_MISS_REASON_CHARS);
+  const greyRaw = Number(source.greyBlocks);
+  const greyBlocks = Number.isFinite(greyRaw)
+    ? Math.min(MAX_ORACLE_MISS_GREY_BLOCKS, Math.max(0, Math.trunc(greyRaw)))
+    : 0;
+  return { reason, greyBlocks };
 }
 
 function validatePayload(payload) {
@@ -781,6 +783,7 @@ function validatePayload(payload) {
       description: String(rawConversionDialog.description || "").replace(/\s+/g, " ").trim().slice(0, 1000)
     }
     : null;
+  const recentChat = sanitiseRecentChat(payload && payload.recentChat);
 
   const hasAutoFixContext = pageErrors.length > 0
     || (conversionDialog && (conversionDialog.title || conversionDialog.description));
@@ -804,6 +807,7 @@ function validatePayload(payload) {
       currentCode,
       pageErrors,
       conversionDialog,
+      recentChat,
       provider,
       model
     }
@@ -1988,7 +1992,10 @@ export function createBackendRuntime(options = {}) {
           );
           return respondJson(200, {
             code: result.code,
-            feedback: result.feedback
+            feedback: result.feedback,
+            outcome: result.outcome,
+            upstreamAttempts: result.upstreamAttempts,
+            validationOk: result.outcome === "ok"
           }, origin, runtimeConfig);
         } finally {
           if (typeof reservation.release === "function") reservation.release();
@@ -2005,6 +2012,29 @@ export function createBackendRuntime(options = {}) {
         const { status, message } = classifyRequestError(error, runtimeConfig);
         const statusCode = /too large/i.test(message) ? 413 : status;
         return respondJson(statusCode, { error: message }, origin, runtimeConfig);
+      }
+    }
+
+    if (pathname === "/vibbit/oracle-miss" && request.method === "POST") {
+      try {
+        if (!isGenerateRequestAuthorised(request, runtimeConfig, sessionStore)) {
+          return respondJson(401, { error: "Unauthorized" }, origin, runtimeConfig);
+        }
+        const session = getRequestSession(request, sessionStore);
+        if (getAuthMode(runtimeConfig) === "classroom" && !session) {
+          return respondJson(401, { error: "Unauthorized" }, origin, runtimeConfig);
+        }
+        const payload = await readJson(request, 16 * 1024);
+        sanitiseOracleMissPayload(payload);
+        const classroomId = session && session.meta && session.meta.classroomId
+          ? String(session.meta.classroomId)
+          : "";
+        // Count only. Do not persist reason, snippets, or code.
+        await usageStore.recordOracleMiss(classroomId || "legacy");
+        return respondJson(200, { ok: true }, origin, runtimeConfig);
+      } catch (error) {
+        const { status, message } = classifyRequestError(error, runtimeConfig);
+        return respondJson(status, { error: message }, origin, runtimeConfig);
       }
     }
 

--- a/apps/backend/src/runtime.test.mjs
+++ b/apps/backend/src/runtime.test.mjs
@@ -149,3 +149,156 @@ test("generate accepts empty request when pageErrors are present", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+function mockChatCompletion(code, feedback = ["ok"]) {
+  return new Response(JSON.stringify({
+    choices: [{
+      message: {
+        content: JSON.stringify({ feedback, code })
+      }
+    }]
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+test("generate retries invalid output through a transcript that includes FAILED_ATTEMPT", async () => {
+  const runtime = createBackendRuntime({
+    env: {
+      VIBBIT_CLASSROOM_ENABLED: "false",
+      SERVER_APP_TOKEN: "",
+      VIBBIT_OPENAI_API_KEY: "test-key",
+      VIBBIT_PROVIDER: "openai",
+      VIBBIT_MODEL: "gpt-4o-mini"
+    },
+    dnsLookup: async () => [{ address: "203.0.113.10", family: 4 }]
+  });
+
+  const failedCode = "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })";
+  const okCode = "basic.showIcon(IconNames.Heart)";
+  const requestBodies = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init = {}) => {
+    requestBodies.push(String(init.body || ""));
+    if (requestBodies.length === 1) {
+      return mockChatCompletion(failedCode, ["arrow"]);
+    }
+    return mockChatCompletion(okCode, ["fixed"]);
+  };
+
+  try {
+    const generate = await runtime.fetch(new Request("https://example.test/vibbit/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        target: "microbit",
+        request: "Show a heart"
+      })
+    }));
+    const body = await generate.json();
+    assert.equal(generate.status, 200, body && body.error ? body.error : "generate failed");
+    assert.equal(body.outcome, "ok");
+    assert.equal(body.upstreamAttempts, 2);
+    assert.equal(body.validationOk, true);
+    assert.match(String(body.code || ""), /showIcon/);
+    assert.equal(requestBodies.length, 2);
+    assert.match(requestBodies[1], /FAILED_ATTEMPT/);
+    assert.ok(requestBodies[1].includes(failedCode));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("generate forwards recentChat into the first user prompt", async () => {
+  const runtime = createBackendRuntime({
+    env: {
+      VIBBIT_CLASSROOM_ENABLED: "false",
+      SERVER_APP_TOKEN: "",
+      VIBBIT_OPENAI_API_KEY: "test-key",
+      VIBBIT_PROVIDER: "openai",
+      VIBBIT_MODEL: "gpt-4o-mini"
+    },
+    dnsLookup: async () => [{ address: "203.0.113.10", family: 4 }]
+  });
+
+  let capturedProviderBody = "";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init = {}) => {
+    capturedProviderBody = String(init.body || "");
+    return mockChatCompletion("basic.showIcon(IconNames.Heart)", ["ok"]);
+  };
+
+  try {
+    const generate = await runtime.fetch(new Request("https://example.test/vibbit/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        target: "microbit",
+        request: "Show a heart",
+        recentChat: [
+          { role: "user", content: "make it blink twice" },
+          { role: "assistant", notes: "toggled the LED each second" }
+        ]
+      })
+    }));
+    const body = await generate.json();
+    assert.equal(generate.status, 200, body && body.error ? body.error : "generate failed");
+    assert.match(capturedProviderBody, /RECENT_CHAT/);
+    assert.match(capturedProviderBody, /make it blink twice/);
+    assert.match(capturedProviderBody, /toggled the LED each second/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("oracle-miss records a classroom miss and never requires code", async () => {
+  const runtime = createBackendRuntime({
+    env: {
+      VIBBIT_DEPLOYMENT_MODE: "self-hosted",
+      VIBBIT_CLASSROOM_ENABLED: "true",
+      VIBBIT_CLASSROOM_CODE: "LEGACY",
+      VIBBIT_CLASSROOM_CODE_AUTO: "false",
+      VIBBIT_TEACHER_DEV_LOGIN: "true",
+      VIBBIT_OPENAI_API_KEY: "server-fallback-key",
+      VIBBIT_PROVIDER: "openai",
+      VIBBIT_MODEL: "gpt-4o-mini"
+    },
+    teacherPortalState: {},
+    persistTeacherPortalState: async () => {},
+    dnsLookup: async () => [{ address: "203.0.113.10", family: 4 }]
+  });
+
+  const denied = await runtime.fetch(new Request("https://example.test/vibbit/oracle-miss", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reason: "grey blocks", greyBlocks: 2 })
+  }));
+  assert.equal(denied.status, 401);
+
+  const connect = await runtime.fetch(new Request("https://example.test/vibbit/connect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ classCode: "LEGACY" })
+  }));
+  assert.equal(connect.status, 200);
+  const { sessionToken } = await connect.json();
+
+  const miss = await runtime.fetch(new Request("https://example.test/vibbit/oracle-miss", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${sessionToken}`
+    },
+    body: JSON.stringify({
+      reason: "Detected 2 grey JavaScript block(s)",
+      greyBlocks: 2,
+      code: "this must not be required or stored"
+    })
+  }));
+  assert.equal(miss.status, 200);
+  const body = await miss.json();
+  assert.equal(body.ok, true);
+  const usage = runtime.usageStore.publicView("legacy");
+  assert.equal(usage.oracleMisses, 1);
+});

--- a/apps/backend/src/usage-store.mjs
+++ b/apps/backend/src/usage-store.mjs
@@ -16,6 +16,7 @@ function emptyBucket() {
     rateLimited: 0,
     inputTokens: 0,
     outputTokens: 0,
+    oracleMisses: 0,
     lastUsedAt: ""
   };
 }
@@ -100,6 +101,11 @@ export function createUsageStore({
         bucket.outputTokens += Math.max(0, Number(outputTokens) || 0);
       });
     },
+    async recordOracleMiss(classroomId) {
+      return record(classroomId, (bucket) => {
+        bucket.oracleMisses += 1;
+      });
+    },
     publicView(classroomId) {
       const today = ensureBucket(classroomId);
       return {
@@ -112,6 +118,7 @@ export function createUsageStore({
         rateLimited: today.rateLimited,
         inputTokens: today.inputTokens,
         outputTokens: today.outputTokens,
+        oracleMisses: today.oracleMisses,
         lastUsedAt: today.lastUsedAt || null
       };
     }
@@ -138,6 +145,7 @@ export function sanitiseUsageState(input) {
         rateLimited: Math.max(0, Number(src.rateLimited) || 0),
         inputTokens: Math.max(0, Number(src.inputTokens) || 0),
         outputTokens: Math.max(0, Number(src.outputTokens) || 0),
+        oracleMisses: Math.max(0, Number(src.oracleMisses) || 0),
         lastUsedAt: String(src.lastUsedAt || "").trim()
       };
     }

--- a/apps/backend/src/usage-store.test.mjs
+++ b/apps/backend/src/usage-store.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createUsageStore, sanitiseUsageState } from "./usage-store.mjs";
+
+test("usage buckets include oracleMisses in sanitise and publicView", async () => {
+  const sanitised = sanitiseUsageState({
+    cls_one: {
+      "2026-08-23": {
+        connects: 1,
+        acceptedGenerations: 2,
+        oracleMisses: 4
+      }
+    }
+  });
+  assert.equal(sanitised.cls_one["2026-08-23"].oracleMisses, 4);
+  assert.equal(sanitised.cls_one["2026-08-23"].connects, 1);
+
+  const missing = sanitiseUsageState({
+    cls_two: {
+      "2026-08-23": { connects: 1 }
+    }
+  });
+  assert.equal(missing.cls_two["2026-08-23"].oracleMisses, 0);
+
+  const store = createUsageStore({
+    now: () => Date.parse("2026-08-23T12:00:00Z")
+  });
+  await store.recordOracleMiss("cls_one");
+  await store.recordOracleMiss("cls_one");
+  const view = store.publicView("cls_one");
+  assert.equal(view.oracleMisses, 2);
+  assert.equal(view.connects, 0);
+});

--- a/scripts/sync-compat-core.mjs
+++ b/scripts/sync-compat-core.mjs
@@ -17,10 +17,14 @@ const markerEndToken = "  // END_SHARED_COMPAT_CORE";
 
 function stripExports(source) {
   let transformed = source
+    .replace(/^export\s+async\s+function\s+/gm, "async function ")
     .replace(/^export\s+(const|function)\s+/gm, "$1 ")
     .replace(/^export\s+\{[\s\S]*?\};?\s*$/gm, "")
     .trim();
   transformed = transformed.replace(/const SHARED_COMPAT_EXPORT_NAMES = \[[\s\S]*?\];\n*/m, "");
+  if (/^export\b/m.test(transformed)) {
+    throw new Error("Compat core still contains export after strip. Update stripExports().");
+  }
   return transformed.trim();
 }
 

--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -10,7 +10,12 @@ export const SHARED_COMPAT_EXPORT_NAMES = [
   "buildSystemPrompt",
   "buildCorrectionInstruction",
   "stubForTarget",
-  "extractGeminiText"
+  "extractGeminiText",
+  "runValidateBlocks",
+  "buildFailedAttemptUserTurn",
+  "buildDecompileFixRequest",
+  "serializeTranscript",
+  "runGenerationLoop"
 ];
 
 export function sanitizeMakeCode(input) {
@@ -1189,4 +1194,195 @@ export function extractGeminiText(response) {
     return "";
   }
   return "";
+}
+
+export function runValidateBlocks(code, target) {
+  return validateBlocksCompatibility(code, target);
+}
+
+function transcriptTurn(role, content) {
+  return { role, content: content == null ? "" : String(content) };
+}
+
+export function buildFailedAttemptUserTurn({
+  code,
+  validation,
+  target,
+  kind,
+  strict = false
+} = {}) {
+  const failedProgramme = code == null ? "" : String(code);
+  const lines = [
+    "<<<FAILED_ATTEMPT>>>",
+    failedProgramme,
+    "<<<END_FAILED_ATTEMPT>>>"
+  ];
+  if (kind === "empty") {
+    lines.push("Your previous reply had empty code. Return a complete MakeCode programme as JSON only.");
+  } else {
+    const violations = validation && Array.isArray(validation.violations) ? validation.violations : [];
+    lines.push(buildCorrectionInstruction(violations, target, { strict: Boolean(strict) }));
+  }
+  lines.push("Return ONLY one compact JSON object: {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript\"}. No prose.");
+  return lines.join("\n");
+}
+
+export function buildDecompileFixRequest({ greyBlocks, snippets, reason } = {}) {
+  const count = Math.max(0, Math.trunc(Number(greyBlocks) || 0));
+  const why = String(reason || "").trim();
+  const examples = (Array.isArray(snippets) ? snippets : [])
+    .map((item) => String(item || "").replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .slice(0, 3);
+  const parts = [
+    "Fix the current JavaScript so MakeCode decompiles it to native Blocks.",
+    "There must be no grey typescript_statement blocks.",
+    "Preserve intended behaviour."
+  ];
+  if (count) parts.push("Grey block count: " + count + ".");
+  if (why) parts.push("Reason: " + why);
+  if (examples.length) parts.push("Grey snippets: " + examples.join(" | "));
+  return parts.join(" ");
+}
+
+export function serializeTranscript(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  const systemParts = [];
+  const rest = [];
+  for (const item of list) {
+    if (!item || typeof item !== "object") continue;
+    const role = item.role;
+    const content = item.content == null ? "" : String(item.content);
+    if (role === "system") {
+      systemParts.push(content);
+      continue;
+    }
+    if (role === "user" || role === "assistant") {
+      rest.push({ role, content });
+    }
+  }
+  const system = systemParts.join("\n\n");
+  if (rest.length === 1 && rest[0].role === "user") {
+    return { system, user: rest[0].content };
+  }
+  const user = rest.map((turn) => {
+    const tag = turn.role === "assistant" ? "<<<ASSISTANT>>>" : "<<<USER>>>";
+    return tag + "\n" + turn.content;
+  }).join("\n");
+  return { system, user };
+}
+
+export async function runGenerationLoop({
+  target,
+  systemPrompt,
+  initialUserPrompt,
+  emptyRetries = 0,
+  validationRetries = 0,
+  maxAttempts = 1,
+  callModel
+} = {}) {
+  const attemptLimit = Math.max(1, Math.trunc(Number(maxAttempts) || 1));
+  let emptyLeft = Math.max(0, Math.trunc(Number(emptyRetries) || 0));
+  let validationLeft = Math.max(0, Math.trunc(Number(validationRetries) || 0));
+  let validationRetried = false;
+
+  const messages = [
+    transcriptTurn("system", systemPrompt),
+    transcriptTurn("user", initialUserPrompt)
+  ];
+  const attempts = [];
+  let last = null;
+
+  while (attempts.length < attemptLimit) {
+    const raw = await callModel(messages);
+    const parsed = parseModelOutput(raw);
+    const code = sanitizeMakeCode(parsed.code);
+    const validation = runValidateBlocks(code, target);
+    // Empty source can pass the static validator; treat it as empty, not ok.
+    const reason = !String(code || "").trim()
+      ? "empty"
+      : (validation.ok ? "ok" : "invalid");
+    last = {
+      raw: raw == null ? "" : String(raw),
+      code,
+      feedback: parsed.feedback,
+      validation,
+      reason
+    };
+    attempts.push(last);
+
+    if (reason === "ok") break;
+    if (attempts.length >= attemptLimit) break;
+
+    if (reason === "empty" && emptyLeft > 0) {
+      emptyLeft -= 1;
+      const assistantContent = String(raw || "").trim() || code || "(empty)";
+      messages.push(transcriptTurn("assistant", assistantContent));
+      messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+        code,
+        validation,
+        target,
+        kind: "empty"
+      })));
+      continue;
+    }
+
+    if (reason === "invalid" && validationLeft > 0) {
+      validationLeft -= 1;
+      messages.push(transcriptTurn("assistant", code));
+      messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+        code,
+        validation,
+        target,
+        kind: "invalid",
+        strict: validationRetried
+      })));
+      validationRetried = true;
+      continue;
+    }
+
+    break;
+  }
+
+  const lastValidation = last && last.validation
+    ? last.validation
+    : { ok: false, violations: [] };
+  const lastFeedback = last && Array.isArray(last.feedback) ? last.feedback : [];
+  const upstreamAttempts = attempts.length;
+
+  if (last && last.reason === "ok") {
+    return {
+      code: last.code,
+      feedback: normaliseFeedback(lastFeedback),
+      validation: lastValidation,
+      upstreamAttempts,
+      outcome: "ok",
+      attempts
+    };
+  }
+
+  if (!last || last.reason === "empty") {
+    return {
+      code: stubForTarget(target),
+      feedback: normaliseFeedback(
+        [...lastFeedback, "Model returned no code; provided fallback stub."]
+      ),
+      validation: lastValidation,
+      upstreamAttempts,
+      outcome: "stub-empty",
+      attempts
+    };
+  }
+
+  const violations = lastValidation.violations || [];
+  return {
+    code: stubForTarget(target),
+    feedback: normaliseFeedback(
+      [...lastFeedback, "Validation fallback: " + (violations.join(", ") || "unknown compatibility issue")]
+    ),
+    validation: lastValidation,
+    upstreamAttempts,
+    outcome: "stub-invalid",
+    attempts
+  };
 }

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -4,8 +4,12 @@ import test from "node:test";
 import {
   TARGET_API_CATALOG,
   buildCorrectionInstruction,
+  buildDecompileFixRequest,
+  buildFailedAttemptUserTurn,
   buildSystemPrompt,
   parseModelOutput,
+  runGenerationLoop,
+  serializeTranscript,
   stubForTarget,
   validateBlocksCompatibility
 } from "./makecode-compat-core.mjs";
@@ -134,4 +138,160 @@ test("correction instruction is safe with no violations", () => {
   assert.ok(message.includes("Maker"));
   assert.ok(!message.includes("Problems:"));
   assert.ok(message.length > 0);
+});
+
+const VALID_HEART = "basic.showIcon(IconNames.Heart)";
+const ARROW_UNSAFE = "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })";
+
+function jsonOutput(code, feedback = ["ok"]) {
+  return JSON.stringify({ feedback, code });
+}
+
+test("failed user turn includes the previous programme and JSON mandate", () => {
+  const turn = buildFailedAttemptUserTurn({
+    code: ARROW_UNSAFE,
+    validation: { ok: false, violations: ["arrow functions"] },
+    target: "microbit",
+    kind: "invalid"
+  });
+  assert.ok(turn.includes("<<<FAILED_ATTEMPT>>>"));
+  assert.ok(turn.includes("<<<END_FAILED_ATTEMPT>>>"));
+  assert.ok(turn.includes(ARROW_UNSAFE));
+  assert.ok(turn.includes("function () { }"));
+  assert.match(turn, /JSON only|compact JSON/i);
+
+  const emptyTurn = buildFailedAttemptUserTurn({
+    code: "",
+    validation: { ok: false, violations: [] },
+    target: "microbit",
+    kind: "empty"
+  });
+  assert.ok(emptyTurn.includes("<<<FAILED_ATTEMPT>>>\n\n<<<END_FAILED_ATTEMPT>>>"));
+  assert.match(emptyTurn, /empty/i);
+  assert.match(emptyTurn, /JSON only|compact JSON/i);
+});
+
+test("generation loop retries empty output and keeps the failed turn", async () => {
+  const calls = [];
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async (messages) => {
+      calls.push(messages.slice());
+      if (calls.length === 1) return jsonOutput("", ["empty"]);
+      return jsonOutput(VALID_HEART, ["heart"]);
+    }
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 2);
+  assert.equal(result.code, VALID_HEART);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0].map((item) => item.role), ["system", "user"]);
+  assert.equal(calls[1][2].role, "assistant");
+  assert.equal(calls[1][3].role, "user");
+  assert.ok(calls[1][3].content.includes("<<<FAILED_ATTEMPT>>>"));
+  assert.match(calls[1][3].content, /empty/i);
+});
+
+test("generation loop retries invalid output and the next user turn includes FAILED_ATTEMPT", async () => {
+  const calls = [];
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async (messages) => {
+      calls.push(messages.slice());
+      if (calls.length === 1) return jsonOutput(ARROW_UNSAFE, ["arrow"]);
+      return jsonOutput(VALID_HEART, ["fixed"]);
+    }
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 2);
+  assert.equal(result.code, VALID_HEART);
+  assert.equal(result.validation.ok, true);
+  assert.equal(calls.length, 2);
+  const second = calls[1];
+  assert.equal(second[0].role, "system");
+  assert.equal(second[1].role, "user");
+  assert.equal(second[2].role, "assistant");
+  assert.equal(second[2].content, ARROW_UNSAFE);
+  assert.ok(second[3].content.includes("<<<FAILED_ATTEMPT>>>"));
+  assert.ok(second[3].content.includes(ARROW_UNSAFE));
+  assert.ok(second[3].content.includes("arrow functions"));
+});
+
+test("generation loop stubs empty and invalid outcomes", async () => {
+  const empty = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async () => jsonOutput("")
+  });
+  assert.equal(empty.outcome, "stub-empty");
+  assert.equal(empty.code, stubForTarget("microbit"));
+  assert.equal(empty.upstreamAttempts, 3);
+  assert.equal(empty.attempts[empty.attempts.length - 1].reason, "empty");
+  assert.ok(empty.feedback.some((line) => /no code/i.test(line)));
+
+  const invalid = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async () => jsonOutput(ARROW_UNSAFE)
+  });
+  assert.equal(invalid.outcome, "stub-invalid");
+  assert.equal(invalid.code, stubForTarget("microbit"));
+  assert.equal(invalid.upstreamAttempts, 3);
+  assert.equal(invalid.validation.ok, false);
+  assert.ok(invalid.feedback.some((line) => /Validation fallback/i.test(line)));
+});
+
+test("serializeTranscript keeps a single user turn and flattens later turns", () => {
+  const single = serializeTranscript([
+    { role: "system", content: "sys-a" },
+    { role: "system", content: "sys-b" },
+    { role: "user", content: "please show a heart" }
+  ]);
+  assert.equal(single.system, "sys-a\n\nsys-b");
+  assert.equal(single.user, "please show a heart");
+
+  const flattened = serializeTranscript([
+    { role: "system", content: "sys" },
+    { role: "user", content: "first" },
+    { role: "assistant", content: ARROW_UNSAFE },
+    { role: "user", content: "<<<FAILED_ATTEMPT>>>\n" + ARROW_UNSAFE }
+  ]);
+  assert.equal(flattened.system, "sys");
+  assert.ok(flattened.user.includes("<<<USER>>>\nfirst"));
+  assert.ok(flattened.user.includes("<<<ASSISTANT>>>\n" + ARROW_UNSAFE));
+  assert.ok(flattened.user.includes("<<<FAILED_ATTEMPT>>>"));
+});
+
+test("decompile fix request uses British spelling and names grey blocks", () => {
+  const text = buildDecompileFixRequest({
+    greyBlocks: 2,
+    snippets: ["foo()", "bar()", "baz()", "dropped"],
+    reason: "Detected 2 grey JavaScript block(s)"
+  });
+  assert.ok(text.includes("behaviour"));
+  assert.ok(text.includes("typescript_statement"));
+  assert.ok(text.includes("Grey block count: 2."));
+  assert.ok(text.includes("Detected 2 grey JavaScript block(s)"));
+  assert.ok(text.includes("foo()"));
+  assert.ok(text.includes("bar()"));
+  assert.ok(text.includes("baz()"));
+  assert.ok(!text.includes("dropped"));
 });

--- a/work.js
+++ b/work.js
@@ -718,6 +718,32 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     return error;
   };
 
+  const createGreyBlockError = (probe) => {
+    const snippets = probe && Array.isArray(probe.snippets) ? probe.snippets.slice(0, 3) : [];
+    const details = snippets.length ? (" Examples: " + snippets.join(" | ")) : "";
+    const reason = (probe && probe.reason) || "Code failed live blocks decompile check.";
+    const error = new Error(reason + details);
+    error.code = "E_GREY_BLOCKS";
+    error.greyBlocks = probe && probe.greyBlocks ? Number(probe.greyBlocks) || 0 : 0;
+    error.snippets = snippets;
+    error.reason = reason;
+    return error;
+  };
+
+  const isGreyBlockError = (error) => {
+    if (!error) return false;
+    if (error.code === "E_GREY_BLOCKS") return true;
+    const message = error && error.message ? String(error.message) : String(error);
+    return /grey JavaScript block/i.test(message);
+  };
+
+  const generatePassedStaticOracle = (result, code) => {
+    if (result && result.validationOk === false) return false;
+    if (result && (result.outcome === "stub-empty" || result.outcome === "stub-invalid")) return false;
+    if (result && result.validationOk === true) return true;
+    return Boolean(code && String(code).trim());
+  };
+
   const isConversionDialogError = (error) => {
     if (!error) return false;
     if (error.code === "E_BLOCKS_CONVERT_DIALOG") return true;
@@ -1993,10 +2019,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
             return;
           }
           if (!probe.ok) {
-            const details = probe.snippets && probe.snippets.length
-              ? (" Examples: " + probe.snippets.join(" | "))
-              : "";
-            throw new Error((probe.reason || "Code failed live blocks decompile check.") + details);
+            throw createGreyBlockError(probe);
           }
           logLine("Live decompile check passed (no grey blocks).");
         });
@@ -2048,6 +2071,11 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     buildCorrectionInstruction,
     stubForTarget,
     extractGeminiText,
+    runValidateBlocks,
+    buildFailedAttemptUserTurn,
+    buildDecompileFixRequest,
+    serializeTranscript,
+    runGenerationLoop,
   } = (() => {
     function sanitizeMakeCode(input) {
       if (!input) return "";
@@ -3227,6 +3255,197 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       return "";
     }
 
+    function runValidateBlocks(code, target) {
+      return validateBlocksCompatibility(code, target);
+    }
+
+    function transcriptTurn(role, content) {
+      return { role, content: content == null ? "" : String(content) };
+    }
+
+    function buildFailedAttemptUserTurn({
+      code,
+      validation,
+      target,
+      kind,
+      strict = false
+    } = {}) {
+      const failedProgramme = code == null ? "" : String(code);
+      const lines = [
+        "<<<FAILED_ATTEMPT>>>",
+        failedProgramme,
+        "<<<END_FAILED_ATTEMPT>>>"
+      ];
+      if (kind === "empty") {
+        lines.push("Your previous reply had empty code. Return a complete MakeCode programme as JSON only.");
+      } else {
+        const violations = validation && Array.isArray(validation.violations) ? validation.violations : [];
+        lines.push(buildCorrectionInstruction(violations, target, { strict: Boolean(strict) }));
+      }
+      lines.push("Return ONLY one compact JSON object: {\"feedback\":[\"short note\"],\"code\":\"MakeCode Static TypeScript\"}. No prose.");
+      return lines.join("\n");
+    }
+
+    function buildDecompileFixRequest({ greyBlocks, snippets, reason } = {}) {
+      const count = Math.max(0, Math.trunc(Number(greyBlocks) || 0));
+      const why = String(reason || "").trim();
+      const examples = (Array.isArray(snippets) ? snippets : [])
+        .map((item) => String(item || "").replace(/\s+/g, " ").trim())
+        .filter(Boolean)
+        .slice(0, 3);
+      const parts = [
+        "Fix the current JavaScript so MakeCode decompiles it to native Blocks.",
+        "There must be no grey typescript_statement blocks.",
+        "Preserve intended behaviour."
+      ];
+      if (count) parts.push("Grey block count: " + count + ".");
+      if (why) parts.push("Reason: " + why);
+      if (examples.length) parts.push("Grey snippets: " + examples.join(" | "));
+      return parts.join(" ");
+    }
+
+    function serializeTranscript(messages) {
+      const list = Array.isArray(messages) ? messages : [];
+      const systemParts = [];
+      const rest = [];
+      for (const item of list) {
+        if (!item || typeof item !== "object") continue;
+        const role = item.role;
+        const content = item.content == null ? "" : String(item.content);
+        if (role === "system") {
+          systemParts.push(content);
+          continue;
+        }
+        if (role === "user" || role === "assistant") {
+          rest.push({ role, content });
+        }
+      }
+      const system = systemParts.join("\n\n");
+      if (rest.length === 1 && rest[0].role === "user") {
+        return { system, user: rest[0].content };
+      }
+      const user = rest.map((turn) => {
+        const tag = turn.role === "assistant" ? "<<<ASSISTANT>>>" : "<<<USER>>>";
+        return tag + "\n" + turn.content;
+      }).join("\n");
+      return { system, user };
+    }
+
+    async function runGenerationLoop({
+      target,
+      systemPrompt,
+      initialUserPrompt,
+      emptyRetries = 0,
+      validationRetries = 0,
+      maxAttempts = 1,
+      callModel
+    } = {}) {
+      const attemptLimit = Math.max(1, Math.trunc(Number(maxAttempts) || 1));
+      let emptyLeft = Math.max(0, Math.trunc(Number(emptyRetries) || 0));
+      let validationLeft = Math.max(0, Math.trunc(Number(validationRetries) || 0));
+      let validationRetried = false;
+
+      const messages = [
+        transcriptTurn("system", systemPrompt),
+        transcriptTurn("user", initialUserPrompt)
+      ];
+      const attempts = [];
+      let last = null;
+
+      while (attempts.length < attemptLimit) {
+        const raw = await callModel(messages);
+        const parsed = parseModelOutput(raw);
+        const code = sanitizeMakeCode(parsed.code);
+        const validation = runValidateBlocks(code, target);
+        // Empty source can pass the static validator; treat it as empty, not ok.
+        const reason = !String(code || "").trim()
+          ? "empty"
+          : (validation.ok ? "ok" : "invalid");
+        last = {
+          raw: raw == null ? "" : String(raw),
+          code,
+          feedback: parsed.feedback,
+          validation,
+          reason
+        };
+        attempts.push(last);
+
+        if (reason === "ok") break;
+        if (attempts.length >= attemptLimit) break;
+
+        if (reason === "empty" && emptyLeft > 0) {
+          emptyLeft -= 1;
+          const assistantContent = String(raw || "").trim() || code || "(empty)";
+          messages.push(transcriptTurn("assistant", assistantContent));
+          messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+            code,
+            validation,
+            target,
+            kind: "empty"
+          })));
+          continue;
+        }
+
+        if (reason === "invalid" && validationLeft > 0) {
+          validationLeft -= 1;
+          messages.push(transcriptTurn("assistant", code));
+          messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+            code,
+            validation,
+            target,
+            kind: "invalid",
+            strict: validationRetried
+          })));
+          validationRetried = true;
+          continue;
+        }
+
+        break;
+      }
+
+      const lastValidation = last && last.validation
+        ? last.validation
+        : { ok: false, violations: [] };
+      const lastFeedback = last && Array.isArray(last.feedback) ? last.feedback : [];
+      const upstreamAttempts = attempts.length;
+
+      if (last && last.reason === "ok") {
+        return {
+          code: last.code,
+          feedback: normaliseFeedback(lastFeedback),
+          validation: lastValidation,
+          upstreamAttempts,
+          outcome: "ok",
+          attempts
+        };
+      }
+
+      if (!last || last.reason === "empty") {
+        return {
+          code: stubForTarget(target),
+          feedback: normaliseFeedback(
+            [...lastFeedback, "Model returned no code; provided fallback stub."]
+          ),
+          validation: lastValidation,
+          upstreamAttempts,
+          outcome: "stub-empty",
+          attempts
+        };
+      }
+
+      const violations = lastValidation.violations || [];
+      return {
+        code: stubForTarget(target),
+        feedback: normaliseFeedback(
+          [...lastFeedback, "Validation fallback: " + (violations.join(", ") || "unknown compatibility issue")]
+        ),
+        validation: lastValidation,
+        upstreamAttempts,
+        outcome: "stub-invalid",
+        attempts
+      };
+    }
+
     return {
       sanitizeMakeCode,
       normaliseFeedback,
@@ -3240,6 +3459,11 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       buildCorrectionInstruction,
       stubForTarget,
       extractGeminiText,
+      runValidateBlocks,
+      buildFailedAttemptUserTurn,
+      buildDecompileFixRequest,
+      serializeTranscript,
+      runGenerationLoop,
     };
   })();
   // END_SHARED_COMPAT_CORE
@@ -3267,6 +3491,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
   /* ── provider calls ──────────────────────────────────────── */
   const REQ_TIMEOUT_MS = 60000;
   const EMPTY_RETRIES = 2;
+  const VALIDATION_RETRIES = 2;
+  const MAX_UPSTREAM_ATTEMPTS = 3;
 
   const withTimeout = (promise, ms, label) => {
     return Promise.race([
@@ -3494,63 +3720,35 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     const providers = { openai: callOpenAI, gemini: callGemini, openrouter: callOpenRouter, opencode: callOpenCode };
     const names = { openai: "OpenAI", gemini: "Gemini", openrouter: "OpenRouter", opencode: "OpenCode" };
     const callProvider = providers[provider] || providers.openai;
+    const providerName = names[provider] || provider;
 
-    const oneAttempt = (extraSystem, insistOnlyCode) => {
-      const prompt = system
-        + (extraSystem ? ("\n" + extraSystem) : "")
-        + (insistOnlyCode ? "\nMANDATE: Output only compact JSON with keys feedback (array) and code (string). No prose." : "");
-      const providerName = names[provider] || provider;
-      logLine("Sending to " + providerName + " (" + (model || "default") + ").");
-      throwIfAborted(signal);
-      return callProvider(apiKey, model, prompt, user, signal).then((raw) => {
+    return runGenerationLoop({
+      target,
+      systemPrompt: system,
+      initialUserPrompt: user,
+      emptyRetries: EMPTY_RETRIES,
+      validationRetries: VALIDATION_RETRIES,
+      maxAttempts: MAX_UPSTREAM_ATTEMPTS,
+      callModel: async (messages) => {
         throwIfAborted(signal);
-        const parsed = parseModelOutput(raw);
-        const code = sanitizeMakeCode(parsed.code);
-        const validation = validateBlocksCompatibility(code, target);
-        return { code, validation, feedback: parsed.feedback };
-      });
-    };
-
-    return oneAttempt(null, false)
-      .then((result) => {
-        if (result.code && result.code.trim()) return result;
-        const retryEmpty = (index, previous) => {
-          if (index >= EMPTY_RETRIES) return previous;
-          const extra = "Your last message had empty code. Return valid JSON only with feedback[] and code string.";
-          return oneAttempt(extra, true).then((next) => {
-            throwIfAborted(signal);
-            if (next.code && next.code.trim()) return next;
-            return retryEmpty(index + 1, next);
-          });
-        };
-        return retryEmpty(0, result);
-      })
-      .then((firstPass) => {
-        if (!firstPass.code || !firstPass.code.trim()) return firstPass;
-        if (firstPass.validation && firstPass.validation.ok) return firstPass;
-        const violations = (firstPass.validation && firstPass.validation.violations) || [];
-        const extra = buildCorrectionInstruction(violations, target, { strict: false });
-        return oneAttempt(extra, true).then((secondPass) => {
-          throwIfAborted(signal);
-          if (secondPass.validation && secondPass.validation.ok) return secondPass;
-          const secondViolations = (secondPass.validation && secondPass.validation.violations) || [];
-          const strictExtra = buildCorrectionInstruction(secondViolations, target, { strict: true });
-          return oneAttempt(strictExtra, true);
-        });
-      })
-      .then((finalResult) => {
-        const feedback = normaliseFeedback(finalResult && finalResult.feedback);
-        if (!finalResult || !finalResult.code || !finalResult.code.trim()) {
-          logLine("Model returned no code after retries. Using minimal stub.");
-          return { code: stubForTarget(target), feedback: normaliseFeedback(feedback.concat(["Model returned no code; provided fallback stub."])) };
-        }
-        if (!finalResult.validation || !finalResult.validation.ok) {
-          const violations = (finalResult.validation && finalResult.validation.violations) || [];
-          logLine("Model output still failed strict validation. Using minimal stub.");
-          return { code: stubForTarget(target), feedback: normaliseFeedback(feedback.concat(["Validation fallback: " + (violations.join(", ") || "unknown compatibility issue")])) };
-        }
-        return { code: finalResult.code, feedback };
-      });
+        const flat = serializeTranscript(messages);
+        logLine("Sending to " + providerName + " (" + (model || "default") + ").");
+        const raw = await callProvider(apiKey, model, flat.system, flat.user, signal);
+        throwIfAborted(signal);
+        return raw;
+      }
+    }).then((result) => {
+      logLine("Generation used " + result.upstreamAttempts + " model attempt(s).");
+      if (result.outcome === "stub-empty") {
+        logLine("Model returned no code after retries. Using minimal stub.");
+      } else if (result.outcome === "stub-invalid") {
+        logLine("Model output still failed strict validation. Using minimal stub.");
+      }
+      return {
+        ...result,
+        validationOk: result.outcome === "ok"
+      };
+    });
   };
 
   const parseJsonSafe = async (response) => {
@@ -3673,6 +3871,25 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       clearTimeout(timeoutId);
       if (signal) signal.removeEventListener("abort", abortFromCaller);
     }
+  };
+
+  const reportOracleMiss = ({ reason, greyBlocks } = {}) => {
+    const mode = storageGet(STORAGE_MODE) || "byok";
+    const safeReason = String(reason || "").replace(/\s+/g, " ").trim().slice(0, 220);
+    const safeGrey = Math.max(0, Math.trunc(Number(greyBlocks) || 0));
+    if (mode !== "managed") {
+      logLine("oracle_miss validation_ok=1 decompile=fail");
+      return;
+    }
+    const backendUrl = getBackendUrl();
+    buildBackendHeaders(backendUrl).then((headers) => fetch(backendUrl + "/vibbit/oracle-miss", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        reason: safeReason,
+        greyBlocks: safeGrey
+      })
+    })).catch(() => {});
   };
 
   const RECENT_CHAT_TOTAL_CHARS = 1200;
@@ -3798,7 +4015,9 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     generationController = new AbortController();
     const signal = generationController.signal;
     let conversionRetryCount = 0;
+    let decompileRetryCount = 0;
     let lastGeneratedCode = "";
+    let lastGeneratePassedOracle = false;
     let finalFeedback = [];
 
     const runGenerationAttempt = (forcedRequest, forcedDlg, options) => {
@@ -3883,7 +4102,14 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
 
           if (mode === "managed") {
             logLine("Mode: Managed backend.");
-            return requestBackendGenerate({ target, request: effectiveRequest, currentCode, pageErrors, conversionDialog }, signal);
+            return requestBackendGenerate({
+              target,
+              request: effectiveRequest,
+              currentCode,
+              pageErrors,
+              conversionDialog,
+              recentChat: recentChatContext
+            }, signal);
           }
 
           const provider = storageGet(STORAGE_PROVIDER) || "openai";
@@ -3900,6 +4126,10 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
 
           const code = extractCode(result && result.code ? result.code : "");
           lastGeneratedCode = code;
+          lastGeneratePassedOracle = generatePassedStaticOracle(result, code);
+          if (result && (result.outcome || result.validationOk != null)) {
+            logLine("Generate outcome=" + (result.outcome || "unknown") + " validationOk=" + (result.validationOk === false ? "0" : "1") + ".");
+          }
           if (!code) {
             finalFeedback = normaliseFeedback(
               finalFeedback.concat(["Model returned no code for this request."]),
@@ -3919,7 +4149,24 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
               throwIfAborted(signal);
               if (isConversionDialogError(error)) throw error;
               const message = error && error.message ? error.message : String(error);
-              if (!/grey JavaScript block/i.test(message)) throw error;
+              if (!isGreyBlockError(error)) throw error;
+              if (decompileRetryCount < 1) {
+                decompileRetryCount += 1;
+                if (lastGeneratePassedOracle) {
+                  reportOracleMiss({
+                    reason: error.reason || message,
+                    greyBlocks: error.greyBlocks
+                  });
+                }
+                includeCurrentForThisSend = true;
+                logLine("Live decompile check failed: " + message);
+                logLine("Retrying once with a decompile-fix request.");
+                return runGenerationAttempt(buildDecompileFixRequest({
+                  greyBlocks: error.greyBlocks,
+                  snippets: error.snippets,
+                  reason: error.reason || message
+                }), null, { snapshot: false });
+              }
               logLine("Live decompile check failed: " + message);
               logLine("Applying minimal fallback stub.");
               finalFeedback = normaliseFeedback(finalFeedback.concat(["Live editor fallback: " + message]));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Vibbit retries were restuffing validator hints into the system prompt and never sending the failed programme back. Attempt N+1 therefore looked like a first try. That is the real naivety in the current codegen loop.

This change makes retries conversational: the next user turn includes the failed code, the static oracle result, and the JSON mandate. The live MakeCode decompile check stays out of the hidden provider loop.

## Scope

- Shared loop driver in `shared/makecode-compat-core.mjs`: `runGenerationLoop`, `runValidateBlocks`, `buildFailedAttemptUserTurn`, `serializeTranscript`.
- Cap hidden upstream attempts at 3.
- Managed and BYOK both use the shared loop. Managed OpenAI-compatible providers receive a real `messages` array. Gemini and BYOK flatten via `serializeTranscript`.
- Managed generate now forwards capped `recentChat` the way BYOK already did.
- Grey-block failure gets one extra student-visible generate, like convert-error, then falls back to the stub.
- `POST /vibbit/oracle-miss` counts `validator.ok && decompile.fail` without storing code. BYOK logs the same locally.
- Sync now strips `export async function`, so the generated `work.js` IIFE stays valid classic script.

## Tradeoffs

- This is still not a tool-calling agent. `runValidateBlocks` is a named function the loop always calls. The model does not emit tool calls.
- Live Blockly decompile remains a browser paste probe. Putting it inside the hidden loop would need a new protocol.
- We did not adopt Pi or DeepSeek Harness. Four-tool terminal loops do not fit a student MakeCode product.

## Blast radius

- Generation quality and retry behaviour for Managed and BYOK.
- Generate JSON now includes `outcome`, `upstreamAttempts`, and `validationOk`. Older clients ignore extra fields.
- New optional generate field: `recentChat`.
- New authenticated route: `POST /vibbit/oracle-miss`.
- Usage buckets gain `oracleMisses`.

## Verification

- `npm test`: 154 passed, 0 failed
- `npm run check:compat-core`
- `node --check work.js`
- `npm run build`
- `npm run package`
- `npm run audit:smoke`: PASS (`output/playwright/audits/smoke-20260823-044322/`)

## Leftover issues

Filed for others. Not in this PR.

- #21 Static validator false-positives on string literals
- #22 Fill `makeCodeValidation` with a pinned compile and decompile runner
- #23 Headless pinned pxt decompiler so grey-block checks are not a student paste
- #24 Do not add native tool-calling until every classroom provider can speak it
- #25 Decide rate-limit accounting before hidden generation steps grow

[Managed mode after smoke generate](https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsmoke_managed_mode.png)
[Managed generate completed in smoke](https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsmoke_managed_feedback.png)
[BYOK generate completed in smoke](https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsmoke_byok_feedback.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

