### PR TITLE
fix(compat): reject basic.onStart so prompt and oracle match live MakeCode

### DIFF
--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -342,7 +342,6 @@ const MICROBIT_CALL_SIGNATURES = [
   { call: "basic.showArrow", minArgs: 1, maxArgs: 2 },
   { call: "basic.clearScreen", minArgs: 0, maxArgs: 0 },
   { call: "basic.forever", minArgs: 1, maxArgs: 1 },
-  { call: "basic.onStart", minArgs: 1, maxArgs: 1 },
   { call: "basic.pause", minArgs: 1, maxArgs: 1 },
   { call: "input.onButtonPressed", minArgs: 2, maxArgs: 2 },
   { call: "input.onGesture", minArgs: 2, maxArgs: 2 },
@@ -414,7 +413,8 @@ const MICROBIT_CALL_SIGNATURES = [
 const MICROBIT_BLOCKS_TEST_EXAMPLES = [
   "input.onButtonPressed(Button.A, function () { basic.showIcon(IconNames.Heart) })",
   "basic.forever(function () { led.toggle(2, 2); basic.pause(100) })",
-  "radio.onReceivedNumber(function (receivedNumber) { basic.showNumber(receivedNumber) })"
+  "radio.onReceivedNumber(function (receivedNumber) { basic.showNumber(receivedNumber) })",
+  "basic.showIcon(IconNames.Duck); basic.pause(1000); basic.clearScreen()"
 ];
 
 function escapeRegExp(value) {
@@ -794,6 +794,7 @@ export function buildTargetPromptExtras(target) {
   return [
     "MICRO:BIT BUILT-IN ICON/ENUM RULES (from pxt-microbit):",
     "If the request matches a built-in icon name (for example duck, heart, skull), prefer basic.showIcon(IconNames.<Name>).",
+    "Write startup behaviour as top-level statements. They become the on start block. Do not call basic.onStart.",
     "For known icons, do NOT hand-draw LED art with basic.showLeds(`...`) unless the user explicitly asks for a custom pattern.",
     "Valid IconNames: " + MICROBIT_ICON_NAMES.map((name) => "IconNames." + name).join(", "),
     "Deprecated alias accepted only for compatibility: IconNames.EigthNote (prefer IconNames.EighthNote).",
@@ -813,7 +814,7 @@ export const TARGET_API_CATALOG = {
   microbit: {
     name: "micro:bit",
     apis: [
-      "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), onStart(handler), pause(ms)",
+      "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), pause(ms)",
       "input: onButtonPressed(Button.A/B/AB, handler), onGesture(Gesture.Shake/Tilt/..., handler), onPinPressed(TouchPin.P0/P1/P2, handler), buttonIsPressed(Button), temperature(), lightLevel(), acceleration(Dimension.X/Y/Z), compassHeading(), rotation(Rotation), magneticForce(Dimension), runningTime()",
       "music: playTone(Note, BeatFraction), ringTone(freq), rest(BeatFraction), beat(BeatFraction), tempo(), setTempo(bpm), changeTempoBy(delta)",
       "led: plot(x,y), unplot(x,y), toggle(x,y), point(x,y), brightness(), setBrightness(n), plotBarGraph(value, high), enable(on)",
@@ -919,7 +920,7 @@ function buildBlockSafeDoRules(target) {
     ];
   }
   return [
-    "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), basic.onStart(function () { }).",
+    "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }). Write startup behaviour as top-level statements; they become the on start block.",
     "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart).",
     ...common
   ];
@@ -937,7 +938,8 @@ const BLOCK_UNSAFE_RULES = [
   "randint(...) (use options._pickRandom() instead).",
   "null, undefined, casts (as), and bitwise operators (| & ^ << >> >>>) with their compound assignments.",
   "setTimeout, setInterval, console, comments, markdown fences, or any prose outside the JSON.",
-  "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=."
+  "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=.",
+  "basic.onStart(...) (write startup code at the top level instead)."
 ];
 
 const OUTPUT_FORMAT_RULES = [
@@ -1046,6 +1048,8 @@ export function validateBlocksCompatibility(code, target) {
   if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
   if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
   if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
+  // Live MakeCode cannot convert basic.onStart() back to the on start block.
+  if (/\bbasic\.onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
   if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
   if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
 
@@ -1119,11 +1123,7 @@ export function stubForTarget(target) {
   if (target === "maker") {
     return ["loops.forever(function () {", "})"].join("\n");
   }
-  return [
-    "basic.onStart(function () {",
-    "    basic.showString(\"Hi\")",
-    "})"
-  ].join("\n");
+  return "basic.showString(\"Hi\")";
 }
 
 // Maps validator findings to concrete, positively-framed corrective actions so a
@@ -1136,6 +1136,7 @@ const VIOLATION_FIX_HINTS = [
   { match: /randint/i, hint: "use options._pickRandom() for random choices" },
   { match: /without initializer/i, hint: "give every let an initial value, e.g. let x = 0" },
   { match: /nested event|non-top-level/i, hint: "move event handlers and functions to the top level" },
+  { match: /basic\.onStart/i, hint: "write startup behaviour as top-level statements; they become the on start block" },
   { match: /enum member/i, hint: "use only valid enum members such as Button.A or IconNames.Heart" },
   { match: /arity/i, hint: "match each block's exact argument count" },
   { match: /Arcade APIs|micro:bit APIs|other target/i, hint: "use only APIs for the selected target" },

--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -1028,7 +1028,7 @@ export function validateBlocksCompatibility(code, target) {
     /(^|[^|])\|([^|=]|$)/m,
     /(^|[^&])&([^&=]|$)/m
   ];
-  const eventRegistrationRe = /\b(?:basic\.forever|basic\.onStart|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
+  const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
   if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
     return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };
@@ -1048,8 +1048,9 @@ export function validateBlocksCompatibility(code, target) {
   if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
   if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
   if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
-  // Live MakeCode cannot convert basic.onStart() back to the on start block.
-  if (/\bbasic\.onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
+  // Live MakeCode cannot convert onStart() / basic.onStart() back to the on start block.
+  // Require a non-member prefix so Arcade APIs such as game.onStart are not banned.
+  if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
   if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
   if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
 

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -127,8 +127,24 @@ test("basic.onStart is rejected even at the top level", () => {
   ].join("\n");
   const nestedResult = validateBlocksCompatibility(nested, "microbit");
   assert.equal(nestedResult.ok, false);
-  assert.ok(nestedResult.violations.includes("nested event registration"));
   assert.ok(nestedResult.violations.includes("basic.onStart()"));
+  assert.ok(
+    !nestedResult.violations.includes("nested event registration"),
+    "onStart is not a nestable handler; the unwrap hint must be the only signal"
+  );
+
+  const bare = "onStart(function () { basic.showString(\"Hi\") })";
+  const bareResult = validateBlocksCompatibility(bare, "microbit");
+  assert.equal(bareResult.ok, false);
+  assert.ok(bareResult.violations.includes("basic.onStart()"));
+
+  const otherTarget = "game.onStart(function () { })";
+  const otherResult = validateBlocksCompatibility(otherTarget, "arcade");
+  assert.ok(!otherResult.violations.includes("basic.onStart()"));
+
+  const inString = "basic.showString(\"call basic.onStart( now\")";
+  const inStringResult = validateBlocksCompatibility(inString, "microbit");
+  assert.ok(!inStringResult.violations.includes("basic.onStart()"), inStringResult.violations.join(", "));
 });
 
 test("correction instruction turns violations into actionable fixes", () => {
@@ -138,6 +154,13 @@ test("correction instruction turns violations into actionable fixes", () => {
   assert.ok(message.includes("options._pickRandom()"));
   assert.ok(message.includes("Problems:"));
   assert.ok(message.includes("Fix by:"));
+});
+
+test("onStart correction tells the model to unwrap, not to hoist the wrapper", () => {
+  const message = buildCorrectionInstruction(["basic.onStart()"], "microbit");
+  assert.match(message, /top-level statements/i);
+  assert.match(message, /on start block/i);
+  assert.ok(!/move event handlers and functions to the top level/i.test(message));
 });
 
 test("strict correction instruction escalates and targets the right platform", () => {

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -9,6 +9,7 @@ import {
   buildSystemPrompt,
   parseModelOutput,
   runGenerationLoop,
+  runValidateBlocks,
   serializeTranscript,
   stubForTarget,
   validateBlocksCompatibility
@@ -36,10 +37,11 @@ test("system prompt grounds the model in target-specific APIs only", () => {
   assert.ok(buildSystemPrompt("microbit").includes("basic:"));
   assert.ok(buildSystemPrompt("arcade").includes("sprites:"));
   assert.ok(buildSystemPrompt("maker").includes("loops:"));
-  // micro:bit on start is a real block and must not be forbidden anymore
   const microbit = buildSystemPrompt("microbit");
-  assert.ok(microbit.includes("onStart(handler)"));
+  assert.ok(!microbit.includes("onStart(handler)"));
   assert.ok(!/onstart functions/i.test(microbit));
+  assert.match(microbit, /top-level statements/i);
+  assert.match(microbit, /on start block/i);
 });
 
 test("block-safe examples stay within each target's API surface", () => {
@@ -52,7 +54,8 @@ test("block-safe examples stay within each target's API surface", () => {
     return prompt.slice(start, end);
   };
   assert.ok(blockSafe(microbit).includes("input.onButtonPressed"));
-  assert.ok(blockSafe(microbit).includes("basic.onStart"));
+  assert.ok(!blockSafe(microbit).includes("basic.onStart"));
+  assert.ok(blockSafe(microbit).includes("top-level statements"));
   assert.ok(!blockSafe(microbit).includes("game.onUpdate"));
   assert.ok(blockSafe(arcade).includes("game.onUpdate"));
   assert.ok(!blockSafe(arcade).includes("input.onButtonPressed"));
@@ -104,7 +107,17 @@ test("fallback stub is block-safe for its target", () => {
   }
 });
 
-test("basic.onStart must be top-level on micro:bit", () => {
+test("basic.onStart is rejected even at the top level", () => {
+  const topLevel = [
+    "basic.onStart(function () {",
+    "    basic.showString(\"Hi\")",
+    "})"
+  ].join("\n");
+  const topLevelResult = validateBlocksCompatibility(topLevel, "microbit");
+  assert.equal(topLevelResult.ok, false);
+  assert.ok(topLevelResult.violations.includes("basic.onStart()"));
+  assert.ok(!topLevelResult.violations.includes("nested event registration"));
+
   const nested = [
     "input.onButtonPressed(Button.A, function () {",
     "    basic.onStart(function () {",
@@ -112,9 +125,10 @@ test("basic.onStart must be top-level on micro:bit", () => {
     "    })",
     "})"
   ].join("\n");
-  const result = validateBlocksCompatibility(nested, "microbit");
-  assert.equal(result.ok, false);
-  assert.ok(result.violations.includes("nested event registration"));
+  const nestedResult = validateBlocksCompatibility(nested, "microbit");
+  assert.equal(nestedResult.ok, false);
+  assert.ok(nestedResult.violations.includes("nested event registration"));
+  assert.ok(nestedResult.violations.includes("basic.onStart()"));
 });
 
 test("correction instruction turns violations into actionable fixes", () => {
@@ -142,6 +156,18 @@ test("correction instruction is safe with no violations", () => {
 
 const VALID_HEART = "basic.showIcon(IconNames.Heart)";
 const ARROW_UNSAFE = "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })";
+const DUCK_ONSTART = [
+  "basic.onStart(function () {",
+  "    basic.showIcon(IconNames.Duck)",
+  "    basic.pause(1000)",
+  "    basic.clearScreen()",
+  "})"
+].join("\n");
+const DUCK_TOPLEVEL = [
+  "basic.showIcon(IconNames.Duck)",
+  "basic.pause(1000)",
+  "basic.clearScreen()"
+].join("\n");
 
 function jsonOutput(code, feedback = ["ok"]) {
   return JSON.stringify({ feedback, code });
@@ -278,6 +304,41 @@ test("serializeTranscript keeps a single user turn and flattens later turns", ()
   assert.ok(flattened.user.includes("<<<USER>>>\nfirst"));
   assert.ok(flattened.user.includes("<<<ASSISTANT>>>\n" + ARROW_UNSAFE));
   assert.ok(flattened.user.includes("<<<FAILED_ATTEMPT>>>"));
+});
+
+test("duck fixture: basic.onStart fails the oracle and top-level statements pass", () => {
+  const wrapped = runValidateBlocks(DUCK_ONSTART, "microbit");
+  assert.equal(wrapped.ok, false);
+  assert.ok(wrapped.violations.includes("basic.onStart()"));
+
+  const topLevel = runValidateBlocks(DUCK_TOPLEVEL, "microbit");
+  assert.equal(topLevel.ok, true, topLevel.violations.join(", "));
+  assert.match(DUCK_TOPLEVEL, /basic\.showIcon\(IconNames\.Duck\)/);
+  assert.match(DUCK_TOPLEVEL, /basic\.pause\(1000\)/);
+  assert.match(DUCK_TOPLEVEL, /basic\.clearScreen\(\)/);
+});
+
+test("generation loop retries basic.onStart with the failed duck programme", async () => {
+  const calls = [];
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "Show the built-in duck icon, pause for one second, then clear the screen.",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async (messages) => {
+      calls.push(messages.slice());
+      if (calls.length === 1) return jsonOutput(DUCK_ONSTART, ["duck"]);
+      return jsonOutput(DUCK_TOPLEVEL, ["fixed"]);
+    }
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 2);
+  assert.equal(result.code, DUCK_TOPLEVEL);
+  assert.ok(calls[1][3].content.includes("<<<FAILED_ATTEMPT>>>"));
+  assert.ok(calls[1][3].content.includes(DUCK_ONSTART));
+  assert.match(calls[1][3].content, /top-level statements/i);
 });
 
 test("decompile fix request uses British spelling and names grey blocks", () => {

--- a/work.js
+++ b/work.js
@@ -3087,7 +3087,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         /(^|[^|])\|([^|=]|$)/m,
         /(^|[^&])&([^&=]|$)/m
       ];
-      const eventRegistrationRe = /\b(?:basic\.forever|basic\.onStart|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
+      const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
       if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
         return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };
@@ -3107,8 +3107,9 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
       if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
       if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
-      // Live MakeCode cannot convert basic.onStart() back to the on start block.
-      if (/\bbasic\.onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
+      // Live MakeCode cannot convert onStart() / basic.onStart() back to the on start block.
+      // Require a non-member prefix so Arcade APIs such as game.onStart are not banned.
+      if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
       if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
       if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
 

--- a/work.js
+++ b/work.js
@@ -2401,7 +2401,6 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       { call: "basic.showArrow", minArgs: 1, maxArgs: 2 },
       { call: "basic.clearScreen", minArgs: 0, maxArgs: 0 },
       { call: "basic.forever", minArgs: 1, maxArgs: 1 },
-      { call: "basic.onStart", minArgs: 1, maxArgs: 1 },
       { call: "basic.pause", minArgs: 1, maxArgs: 1 },
       { call: "input.onButtonPressed", minArgs: 2, maxArgs: 2 },
       { call: "input.onGesture", minArgs: 2, maxArgs: 2 },
@@ -2473,7 +2472,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
     const MICROBIT_BLOCKS_TEST_EXAMPLES = [
       "input.onButtonPressed(Button.A, function () { basic.showIcon(IconNames.Heart) })",
       "basic.forever(function () { led.toggle(2, 2); basic.pause(100) })",
-      "radio.onReceivedNumber(function (receivedNumber) { basic.showNumber(receivedNumber) })"
+      "radio.onReceivedNumber(function (receivedNumber) { basic.showNumber(receivedNumber) })",
+      "basic.showIcon(IconNames.Duck); basic.pause(1000); basic.clearScreen()"
     ];
 
     function escapeRegExp(value) {
@@ -2853,6 +2853,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       return [
         "MICRO:BIT BUILT-IN ICON/ENUM RULES (from pxt-microbit):",
         "If the request matches a built-in icon name (for example duck, heart, skull), prefer basic.showIcon(IconNames.<Name>).",
+        "Write startup behaviour as top-level statements. They become the on start block. Do not call basic.onStart.",
         "For known icons, do NOT hand-draw LED art with basic.showLeds(`...`) unless the user explicitly asks for a custom pattern.",
         "Valid IconNames: " + MICROBIT_ICON_NAMES.map((name) => "IconNames." + name).join(", "),
         "Deprecated alias accepted only for compatibility: IconNames.EigthNote (prefer IconNames.EighthNote).",
@@ -2872,7 +2873,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       microbit: {
         name: "micro:bit",
         apis: [
-          "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), onStart(handler), pause(ms)",
+          "basic: showNumber(n), showString(s), showIcon(IconNames), showLeds(`...`), showArrow(ArrowNames), clearScreen(), forever(handler), pause(ms)",
           "input: onButtonPressed(Button.A/B/AB, handler), onGesture(Gesture.Shake/Tilt/..., handler), onPinPressed(TouchPin.P0/P1/P2, handler), buttonIsPressed(Button), temperature(), lightLevel(), acceleration(Dimension.X/Y/Z), compassHeading(), rotation(Rotation), magneticForce(Dimension), runningTime()",
           "music: playTone(Note, BeatFraction), ringTone(freq), rest(BeatFraction), beat(BeatFraction), tempo(), setTempo(bpm), changeTempoBy(delta)",
           "led: plot(x,y), unplot(x,y), toggle(x,y), point(x,y), brightness(), setBrightness(n), plotBarGraph(value, high), enable(on)",
@@ -2978,7 +2979,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         ];
       }
       return [
-        "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }), basic.onStart(function () { }).",
+        "Use event handlers and loops, e.g. input.onButtonPressed(Button.A, function () { }), basic.forever(function () { }). Write startup behaviour as top-level statements; they become the on start block.",
         "Match each block's exact argument count and use only valid enum members (e.g. Button.A, IconNames.Heart).",
         ...common
       ];
@@ -2996,7 +2997,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       "randint(...) (use options._pickRandom() instead).",
       "null, undefined, casts (as), and bitwise operators (| & ^ << >> >>>) with their compound assignments.",
       "setTimeout, setInterval, console, comments, markdown fences, or any prose outside the JSON.",
-      "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=."
+      "Returning a value from a callback/handler, optional or default parameters in your own functions, and assignment operators other than =, +=, -=.",
+      "basic.onStart(...) (write startup code at the top level instead)."
     ];
 
     const OUTPUT_FORMAT_RULES = [
@@ -3105,6 +3107,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
       if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
       if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
+      // Live MakeCode cannot convert basic.onStart() back to the on start block.
+      if (/\bbasic\.onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
       if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
       if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
 
@@ -3178,11 +3182,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       if (target === "maker") {
         return ["loops.forever(function () {", "})"].join("\n");
       }
-      return [
-        "basic.onStart(function () {",
-        "    basic.showString(\"Hi\")",
-        "})"
-      ].join("\n");
+      return "basic.showString(\"Hi\")";
     }
 
     // Maps validator findings to concrete, positively-framed corrective actions so a
@@ -3195,6 +3195,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       { match: /randint/i, hint: "use options._pickRandom() for random choices" },
       { match: /without initializer/i, hint: "give every let an initial value, e.g. let x = 0" },
       { match: /nested event|non-top-level/i, hint: "move event handlers and functions to the top level" },
+      { match: /basic\.onStart/i, hint: "write startup behaviour as top-level statements; they become the on start block" },
       { match: /enum member/i, hint: "use only valid enum members such as Button.A or IconNames.Heart" },
       { match: /arity/i, hint: "match each block's exact argument count" },
       { match: /Arcade APIs|micro:bit APIs|other target/i, hint: "use only APIs for the selected target" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #26.

## Why

Live MakeCode cannot convert `basic.onStart(function () { ... })` back to Blocks. The editor underlines `basic.onStart` and shows the convert dialog. The static oracle still accepted it, and the system prompt listed `onStart(handler)` as an available API.

The duck programme from the live harness made this obvious:

```ts
basic.onStart(function () {
    basic.showIcon(IconNames.Duck)
    basic.pause(1000)
    basic.clearScreen()
})
```

That passed `runValidateBlocks`. Pasting it into `makecode.microbit.org` and switching to Blocks failed. The student-visible convert retry then produced top-level statements, which decompile to the native `on start` block. Prompt and oracle should already demand that shape.

## Scope

- Drop `onStart(handler)` from the micro:bit API list and `MICROBIT_CALL_SIGNATURES`.
- Tell the model to write startup as top-level statements. They become the on start block.
- Ban `basic.onStart(...)` in `NEVER USE` and in `runValidateBlocks`.
- Also reject bare `onStart(...)` from the old API list, without matching Arcade members such as `game.onStart`.
- Do not treat `onStart` as a nestable event handler. Nested wrappers must not also fire "move event handlers to the top level".
- Change the micro:bit stub to `basic.showString("Hi")` so the fallback itself stays oracle-clean.
- Retry hint: write startup as top-level statements.
- Duck few-shot example plus duck fixture tests, including a generation-loop retry that puts the wrapper in `FAILED_ATTEMPT`.

## Tradeoffs

- `basic.onStart` may still compile in pxt. We keep it out of generated code until a later pxt release decompiles it cleanly.
- The hidden provider loop still uses the static oracle only. Live decompile stays a browser paste probe.
- This does not add a headless pxt decompiler (#23) or native tool-calling (#24).

## Blast radius

- Shared prompt, validator, stub, and retry hint in `shared/makecode-compat-core.mjs`, synced into `work.js`.
- Managed and BYOK both pick this up through the shared loop.
- Existing generated programmes that wrap startup in `basic.onStart` will now fail the oracle and retry.

## Verification

- `npm test`: 157 passed, 0 failed
- `npm run check:compat-core`
- `node --check work.js`
- `npm run build` and `npm run package`
- `npm run audit:smoke`: PASS (`output/playwright/audits/smoke-20260823-062536/`)
- Live MakeCode paste on `https://makecode.microbit.org/#newproject`:
  - Wrapped `basic.onStart` duck programme → convert dialog, red underline on `basic.onStart`
  - Top-level duck statements → native `on start` → show icon → pause 1000 → clear screen

[Wrapped basic.onStart still fails live convert](https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flive_duck_onstart_convert_dialog.png)
[Top-level duck statements decompile to native on start blocks](https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flive_duck_toplevel_native_blocks.png)

## Adversarial review

Fixed before merge:

- Nested `basic.onStart` also reported `nested event registration`, which told the model to hoist the wrapper. That still fails live convert. `onStart` is no longer an event-registration token.
- Bare `onStart()` from the old `onStart(handler)` API line now fails the oracle. `game.onStart` does not.
- String literals containing `basic.onStart(` do not trip the new rule (uses `stringStrippedCode`).

Accepted nits, not blocking:

- `NEVER USE` is shared, so Arcade/Maker prompts also mention `basic.onStart`. Harmless.
- The prompt names the forbidden API more than once. The oracle still catches a copy.

## Leftover

Not in this PR.

- #21 Static validator false-positives on string literals
- #23 Headless pinned pxt decompiler
- #24 Native tool-calling
- #25 Rate-limit accounting


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02cbc-1f0b-7c1d-8d54-c3cd2a9fdb7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

