### PR TITLE
fix(compat): ignore forbidden tokens inside string literals

### DIFF
--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -421,6 +421,34 @@ function escapeRegExp(value) {
   return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function templateHasInterpolation(source) {
+  const input = String(source || "");
+  let inTemplate = false;
+  let escaped = false;
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    const next = i + 1 < input.length ? input[i + 1] : "";
+    if (!inTemplate) {
+      if (char === "`") inTemplate = true;
+      continue;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "`") {
+      inTemplate = false;
+      continue;
+    }
+    if (char === "$" && next === "{") return true;
+  }
+  return false;
+}
+
 function stripNonCodeSegments(source) {
   const input = String(source || "");
   const chars = input.split("");
@@ -1010,7 +1038,7 @@ export function validateBlocksCompatibility(code, target) {
     { re: /\bnew\s+[A-Z_a-z]/g, why: "new constructor" },
     { re: /\bPromise\b|\basync\b|\bawait\b/g, why: "promises/async" },
     { re: /\bimport\s|\bexport\s/g, why: "import/export" },
-    { re: /\$\{[^}]+\}/g, why: "template string interpolation" },
+    { test: templateHasInterpolation, why: "template string interpolation" },
     { re: /\.\s*(map|forEach|filter|reduce|find|some|every)\s*\(/g, why: "higher-order array methods" },
     { re: /\bnamespace\b|\bmodule\b/g, why: "namespaces/modules" },
     { re: /\benum\b|\binterface\b|\btype\s+[A-Z_a-z]/g, why: "TS types/enums" },
@@ -1030,33 +1058,46 @@ export function validateBlocksCompatibility(code, target) {
   ];
   const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
-  if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
+  const codeView = stripNonCodeSegments(code);
+  const stringView = code.replace(
+    /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/g,
+    (match) => " ".repeat(match.length)
+  );
+
+  if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(codeView)) {
     return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };
   }
-  if (target === "arcade" && (/led\./i.test(code) || /radio\./i.test(code))) {
+  if (target === "arcade" && (/led\./i.test(codeView) || /radio\./i.test(codeView))) {
     return { ok: false, violations: ["micro:bit APIs in Arcade"] };
   }
 
   const violations = [];
-  const stringStrippedCode = code.replace(
-    /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/g,
-    (match) => " ".repeat(match.length)
-  );
   for (const rule of rules) {
-    if (rule.re.test(code)) violations.push(rule.why);
+    if (typeof rule.test === "function") {
+      if (rule.test(code)) violations.push(rule.why);
+      continue;
+    }
+    const haystack = (rule.why === "line comments" || rule.why === "block comments")
+      ? stringView
+      : codeView;
+    rule.re.lastIndex = 0;
+    if (rule.re.test(haystack)) violations.push(rule.why);
   }
-  if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
-  if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
-  if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
+  if (/\bnull\b/.test(stringView)) violations.push("null");
+  if (/\bundefined\b/.test(stringView)) violations.push("undefined");
+  if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringView)) violations.push("casts");
   // Live MakeCode cannot convert onStart() / basic.onStart() back to the on start block.
   // Require a non-member prefix so Arcade APIs such as game.onStart are not banned.
-  if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
-  if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
-  if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
+  if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringView)) violations.push("basic.onStart()");
+  if (bitwiseRules.some((rule) => {
+    rule.lastIndex = 0;
+    return rule.test(codeView);
+  })) violations.push("bitwise operators");
+  if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(codeView)) violations.push("for...in loops");
 
   const forHeaderRe = /for\s*\(([^)]*)\)/g;
   let forMatch;
-  while ((forMatch = forHeaderRe.exec(code))) {
+  while ((forMatch = forHeaderRe.exec(codeView))) {
     const header = forMatch[1].trim();
     if (/\bof\b/.test(header)) continue;
     const parts = header.split(";").map((part) => part.trim());
@@ -1078,7 +1119,7 @@ export function validateBlocksCompatibility(code, target) {
     }
   }
 
-  const lines = code.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const lines = codeView.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
   let depth = 0;
   for (const line of lines) {
     const trimmed = line.trim();

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -147,6 +147,65 @@ test("basic.onStart is rejected even at the top level", () => {
   assert.ok(!inStringResult.violations.includes("basic.onStart()"), inStringResult.violations.join(", "));
 });
 
+test("string literals do not trip forbidden-construct rules", () => {
+  const arrowText = 'basic.showString("press => to continue")';
+  const arrowResult = validateBlocksCompatibility(arrowText, "microbit");
+  assert.equal(arrowResult.ok, true, arrowResult.violations.join(", "));
+
+  const classText = 'basic.showString("class")';
+  const classResult = validateBlocksCompatibility(classText, "microbit");
+  assert.equal(classResult.ok, true, classResult.violations.join(", "));
+
+  const ledPattern = [
+    "basic.showLeds(`",
+    "    . . class . .",
+    "    . . . . .",
+    "    . . . . .",
+    "    . . . . .",
+    "    . . . . .",
+    "`)"
+  ].join("\n");
+  const ledResult = validateBlocksCompatibility(ledPattern, "microbit");
+  assert.equal(ledResult.ok, true, ledResult.violations.join(", "));
+  assert.ok(!ledResult.violations.includes("classes"));
+  assert.ok(!ledResult.violations.includes("template string interpolation"));
+});
+
+test("comments inside strings are not treated as comments", () => {
+  const url = 'basic.showString("http://makecode.microbit.org")';
+  const urlResult = validateBlocksCompatibility(url, "microbit");
+  assert.equal(urlResult.ok, true, urlResult.violations.join(", "));
+  assert.ok(!urlResult.violations.includes("line comments"));
+
+  const nested = 'basic.showString("/* class */")';
+  const nestedResult = validateBlocksCompatibility(nested, "microbit");
+  assert.equal(nestedResult.ok, true, nestedResult.violations.join(", "));
+  assert.ok(!nestedResult.violations.includes("block comments"));
+  assert.ok(!nestedResult.violations.includes("classes"));
+});
+
+test("real forbidden constructs still fail after string stripping", () => {
+  const arrow = "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })";
+  const arrowResult = validateBlocksCompatibility(arrow, "microbit");
+  assert.equal(arrowResult.ok, false);
+  assert.ok(arrowResult.violations.includes("arrow functions"));
+
+  const constructed = "let sprite = new Sprite()";
+  const constructedResult = validateBlocksCompatibility(constructed, "arcade");
+  assert.equal(constructedResult.ok, false);
+  assert.ok(constructedResult.violations.includes("new constructor"));
+
+  const commented = 'basic.showString("Hi")\n// students: press A';
+  const commentedResult = validateBlocksCompatibility(commented, "microbit");
+  assert.equal(commentedResult.ok, false);
+  assert.ok(commentedResult.violations.includes("line comments"));
+
+  const interpolated = "basic.showString(`press ${name}`)";
+  const interpolatedResult = validateBlocksCompatibility(interpolated, "microbit");
+  assert.equal(interpolatedResult.ok, false);
+  assert.ok(interpolatedResult.violations.includes("template string interpolation"));
+});
+
 test("correction instruction turns violations into actionable fixes", () => {
   const message = buildCorrectionInstruction(["arrow functions", "randint()"], "microbit");
   assert.ok(message.includes("micro:bit"));
@@ -274,6 +333,23 @@ test("generation loop retries invalid output and the next user turn includes FAI
   assert.ok(second[3].content.includes("<<<FAILED_ATTEMPT>>>"));
   assert.ok(second[3].content.includes(ARROW_UNSAFE));
   assert.ok(second[3].content.includes("arrow functions"));
+});
+
+test("generation loop accepts legal programmes whose strings mention forbidden tokens", async () => {
+  const legal = 'basic.showString("press => to continue")';
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "prompt the student",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    callModel: async () => jsonOutput(legal, ["ok"])
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 1);
+  assert.equal(result.code, legal);
+  assert.equal(result.validation.ok, true);
 });
 
 test("generation loop stubs empty and invalid outcomes", async () => {

--- a/work.js
+++ b/work.js
@@ -2480,6 +2480,34 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }
 
+    function templateHasInterpolation(source) {
+      const input = String(source || "");
+      let inTemplate = false;
+      let escaped = false;
+      for (let i = 0; i < input.length; i += 1) {
+        const char = input[i];
+        const next = i + 1 < input.length ? input[i + 1] : "";
+        if (!inTemplate) {
+          if (char === "`") inTemplate = true;
+          continue;
+        }
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (char === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (char === "`") {
+          inTemplate = false;
+          continue;
+        }
+        if (char === "$" && next === "{") return true;
+      }
+      return false;
+    }
+
     function stripNonCodeSegments(source) {
       const input = String(source || "");
       const chars = input.split("");
@@ -3069,7 +3097,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         { re: /\bnew\s+[A-Z_a-z]/g, why: "new constructor" },
         { re: /\bPromise\b|\basync\b|\bawait\b/g, why: "promises/async" },
         { re: /\bimport\s|\bexport\s/g, why: "import/export" },
-        { re: /\$\{[^}]+\}/g, why: "template string interpolation" },
+        { test: templateHasInterpolation, why: "template string interpolation" },
         { re: /\.\s*(map|forEach|filter|reduce|find|some|every)\s*\(/g, why: "higher-order array methods" },
         { re: /\bnamespace\b|\bmodule\b/g, why: "namespaces/modules" },
         { re: /\benum\b|\binterface\b|\btype\s+[A-Z_a-z]/g, why: "TS types/enums" },
@@ -3089,33 +3117,46 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       ];
       const eventRegistrationRe = /\b(?:basic\.forever|loops\.forever|input\.on[A-Z_a-z0-9_]*|radio\.on[A-Z_a-z0-9_]*|pins\.on[A-Z_a-z0-9_]*|controller\.[A-Z_a-z0-9_]*\.onEvent|controller\.on[A-Z_a-z0-9_]*|sprites\.on[A-Z_a-z0-9_]*|scene\.on[A-Z_a-z0-9_]*|game\.on[A-Z_a-z0-9_]*|info\.on[A-Z_a-z0-9_]*|control\.inBackground)\s*\(/;
 
-      if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(code)) {
+      const codeView = stripNonCodeSegments(code);
+      const stringView = code.replace(
+        /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/g,
+        (match) => " ".repeat(match.length)
+      );
+
+      if ((target === "microbit" || target === "maker") && /sprites\.|controller\.|scene\.|game\.onUpdate/i.test(codeView)) {
         return { ok: false, violations: ["Arcade APIs in micro:bit/Maker"] };
       }
-      if (target === "arcade" && (/led\./i.test(code) || /radio\./i.test(code))) {
+      if (target === "arcade" && (/led\./i.test(codeView) || /radio\./i.test(codeView))) {
         return { ok: false, violations: ["micro:bit APIs in Arcade"] };
       }
 
       const violations = [];
-      const stringStrippedCode = code.replace(
-        /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/g,
-        (match) => " ".repeat(match.length)
-      );
       for (const rule of rules) {
-        if (rule.re.test(code)) violations.push(rule.why);
+        if (rule.why === "template string interpolation") {
+          if (templateHasInterpolation(code)) violations.push(rule.why);
+          continue;
+        }
+        const haystack = (rule.why === "line comments" || rule.why === "block comments")
+          ? stringView
+          : codeView;
+        rule.re.lastIndex = 0;
+        if (rule.re.test(haystack)) violations.push(rule.why);
       }
-      if (/\bnull\b/.test(stringStrippedCode)) violations.push("null");
-      if (/\bundefined\b/.test(stringStrippedCode)) violations.push("undefined");
-      if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringStrippedCode)) violations.push("casts");
+      if (/\bnull\b/.test(stringView)) violations.push("null");
+      if (/\bundefined\b/.test(stringView)) violations.push("undefined");
+      if (/\bas\s+[A-Z_a-z][A-Z_a-z0-9_.]*/.test(stringView)) violations.push("casts");
       // Live MakeCode cannot convert onStart() / basic.onStart() back to the on start block.
       // Require a non-member prefix so Arcade APIs such as game.onStart are not banned.
-      if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringStrippedCode)) violations.push("basic.onStart()");
-      if (bitwiseRules.some((rule) => rule.test(code))) violations.push("bitwise operators");
-      if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(code)) violations.push("for...in loops");
+      if (/(?:^|[^\w.])(?:basic\.)?onStart\s*\(/.test(stringView)) violations.push("basic.onStart()");
+      if (bitwiseRules.some((rule) => {
+        rule.lastIndex = 0;
+        return rule.test(codeView);
+      })) violations.push("bitwise operators");
+      if (/\bfor\s*\([^)]*\bin\b[^)]*\)/.test(codeView)) violations.push("for...in loops");
 
       const forHeaderRe = /for\s*\(([^)]*)\)/g;
       let forMatch;
-      while ((forMatch = forHeaderRe.exec(code))) {
+      while ((forMatch = forHeaderRe.exec(codeView))) {
         const header = forMatch[1].trim();
         if (/\bof\b/.test(header)) continue;
         const parts = header.split(";").map((part) => part.trim());
@@ -3137,7 +3178,7 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         }
       }
 
-      const lines = code.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+      const lines = codeView.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
       let depth = 0;
       for (const line of lines) {
         const trimmed = line.trim();

--- a/work.js
+++ b/work.js
@@ -3132,8 +3132,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
 
       const violations = [];
       for (const rule of rules) {
-        if (rule.why === "template string interpolation") {
-          if (templateHasInterpolation(code)) violations.push(rule.why);
+        if (typeof rule.test === "function") {
+          if (rule.test(code)) violations.push(rule.why);
           continue;
         }
         const haystack = (rule.why === "line comments" || rule.why === "block comments")


### PR DESCRIPTION
## Why

`validateBlocksCompatibility` is the named oracle for hidden retries. A legal programme such as `basic.showString("press => to continue")` was failing that oracle because most forbidden-construct regexes still ran against raw source. That burned an upstream attempt and could replace working code with the fallback stub.

## Scope

- `shared/makecode-compat-core.mjs` `validateBlocksCompatibility` now runs regex, bitwise, for-loop, target-API, and brace-depth checks on `stripNonCodeSegments` (strings and comments blanked).
- Comment bans still run on a string-stripped view, so real `//` and `/* */` comments fail and comment text inside strings does not.
- Template interpolation is detected only inside backticks via `templateHasInterpolation`.
- `work.js` is regenerated from the shared core.
- Tests cover the issue 21 fixtures, comment-in-string cases, real `=>` / `new` / comments / `${}`, and a generation-loop pass for a legal `showString` that mentions `=>`.

## Tradeoffs

I also moved target-API and brace-depth checks onto the stripped view. Those were the same class of miss (a string could mention `sprites.` or contain `{`). I did not export a new public helper.

## Blast Radius

Students stop losing a generate retry when a string contains a forbidden token. Maintainers inherit one extra view (`codeView` vs `stringView`) in the oracle. Real arrow functions, `new`, comments, and template interpolations still fail.

## Verification

- Reproduced on `main`. `basic.showString("press => to continue")` returned `arrow functions`.
- `node --test shared/makecode-compat-core.test.mjs` 25 passed, including the new cases.
- `npm run sync:compat-core` and `npm run check:compat-core`.

Closes #21
