### PR TITLE
fix(backend): count one quota unit per student generate

### DIFF
--- a/apps/backend/src/rate-limit.mjs
+++ b/apps/backend/src/rate-limit.mjs
@@ -174,6 +174,8 @@ export function createRateLimitController(envInput = {}, {
     },
 
     async reserveGenerate({ sessionToken = "", classroomId = "" } = {}) {
+      // One reservation covers the whole student generate, including hidden
+      // provider retries. Meter those retries on usage.upstreamAttempts, not quota.
       // Canonical session id only — never trust raw request headers for bucket keys.
       const canonicalSession = String(sessionToken || "").trim();
       const sessionKey = `generate:session:${canonicalSession || "anonymous"}`;

--- a/apps/backend/src/rate-limit.test.mjs
+++ b/apps/backend/src/rate-limit.test.mjs
@@ -530,3 +530,109 @@ test("revoked classroom session does not consume daily generate quota", async ()
   assert.equal(generate.status, 401);
   assert.equal(rateLimits.getClassroomDayUsage("cls_rate_a"), 0);
 });
+
+test("hidden provider retries do not spend extra daily quota", async () => {
+  const runtime = createRateLimitRuntime({
+    env: {
+      VIBBIT_RATE_GENERATE_PER_SESSION_PER_MIN: "100",
+      VIBBIT_RATE_GENERATE_PER_CLASSROOM_PER_MIN: "100",
+      VIBBIT_RATE_GENERATE_PER_CLASSROOM_PER_DAY: "1",
+      VIBBIT_RATE_CONCURRENT_PER_CLASSROOM: "10",
+      VIBBIT_RATE_CONCURRENT_GLOBAL: "100"
+    }
+  });
+
+  const connect = await connectWithCode(runtime, "RATEA");
+  assert.equal(connect.status, 200);
+  const { sessionToken } = await connect.json();
+
+  let upstreamCalls = 0;
+  const restoreFetch = mockUpstreamFetch(async () => {
+    upstreamCalls += 1;
+    if (upstreamCalls === 1) {
+      return new Response(JSON.stringify({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              feedback: ["arrow"],
+              code: "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })"
+            })
+          }
+        }]
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    return mockGenerateResponse();
+  });
+
+  try {
+    const first = await generateWithSession(runtime, sessionToken);
+    const firstBody = await first.json();
+    assert.equal(first.status, 200, firstBody && firstBody.error ? firstBody.error : "generate failed");
+    assert.equal(firstBody.upstreamAttempts, 2);
+    const usage = runtime.usageStore.getToday("cls_rate_a");
+    assert.equal(usage.acceptedGenerations, 1);
+    assert.equal(usage.upstreamAttempts, 2);
+
+    const second = await generateWithSession(runtime, sessionToken);
+    assert.equal(second.status, 429);
+    const limited = await second.json();
+    assert.equal(limited.reason, "generate_daily_quota");
+    assert.equal(upstreamCalls, 2);
+    assert.equal(runtime.usageStore.getToday("cls_rate_a").acceptedGenerations, 1);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("hidden provider retries stay capped at three upstream attempts", async () => {
+  const runtime = createRateLimitRuntime({
+    env: {
+      VIBBIT_EMPTY_RETRIES: "5",
+      VIBBIT_VALIDATION_RETRIES: "5",
+      VIBBIT_RATE_GENERATE_PER_SESSION_PER_MIN: "100",
+      VIBBIT_RATE_GENERATE_PER_CLASSROOM_PER_MIN: "100",
+      VIBBIT_RATE_GENERATE_PER_CLASSROOM_PER_DAY: "10",
+      VIBBIT_RATE_CONCURRENT_PER_CLASSROOM: "10",
+      VIBBIT_RATE_CONCURRENT_GLOBAL: "100"
+    }
+  });
+
+  const connect = await connectWithCode(runtime, "RATEA");
+  assert.equal(connect.status, 200);
+  const { sessionToken } = await connect.json();
+
+  let upstreamCalls = 0;
+  const restoreFetch = mockUpstreamFetch(async () => {
+    upstreamCalls += 1;
+    return new Response(JSON.stringify({
+      choices: [{
+        message: {
+          content: JSON.stringify({
+            feedback: ["arrow"],
+            code: "input.onButtonPressed(Button.A, () => { basic.showIcon(IconNames.Heart) })"
+          })
+        }
+      }]
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  });
+
+  try {
+    const response = await generateWithSession(runtime, sessionToken);
+    const body = await response.json();
+    assert.equal(response.status, 200, body && body.error ? body.error : "generate failed");
+    assert.equal(body.outcome, "stub-invalid");
+    assert.equal(body.upstreamAttempts, 3);
+    assert.equal(upstreamCalls, 3);
+    const usage = runtime.usageStore.getToday("cls_rate_a");
+    assert.equal(usage.acceptedGenerations, 1);
+    assert.equal(usage.upstreamAttempts, 3);
+  } finally {
+    restoreFetch();
+  }
+});

--- a/apps/backend/src/runtime.mjs
+++ b/apps/backend/src/runtime.mjs
@@ -41,6 +41,7 @@ const MAX_RECENT_CHAT_TURNS = 4;
 const MAX_RECENT_CHAT_CHARS = 400;
 const MAX_ORACLE_MISS_REASON_CHARS = 220;
 const MAX_ORACLE_MISS_GREY_BLOCKS = 32;
+// Hidden retries stay inside one reservation. Keep this cap until quota accounting changes.
 const MAX_UPSTREAM_ATTEMPTS = 3;
 const CLASS_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ";
 const CLASS_CODE_LENGTH = 10;

--- a/apps/backend/src/teacher-portal.mjs
+++ b/apps/backend/src/teacher-portal.mjs
@@ -442,7 +442,7 @@ function renderCredentialProfileOptions({
 function formatUsageLine(usage, dailyLimit) {
   const used = Number(usage && usage.acceptedGenerations) || 0;
   const limit = Math.max(1, Number(dailyLimit) || 500);
-  return `${used} of ${limit} used today`;
+  return `${used} of ${limit} used today (hidden retries included)`;
 }
 
 function withTimeout(promise, timeoutMs) {

--- a/apps/backend/src/teacher-portal.test.mjs
+++ b/apps/backend/src/teacher-portal.test.mjs
@@ -89,7 +89,7 @@ test("teacher can sign in locally, test-and-save an AI account, create a classro
   assert.match(html, /AI accounts/);
   assert.match(html, /School OpenAI/);
   assert.match(html, /Period 3/);
-  assert.match(html, /of 500 used today/);
+  assert.match(html, /of 500 used today \(hidden retries included\)/);
   assert.match(html, /Ready/);
   const codeMatch = html.match(/class="code code-lg">([A-Z]{5}-[A-Z]{5})</);
   assert.ok(codeMatch, "expected classroom code in dashboard");


### PR DESCRIPTION
## Why

Classroom generate limits must stay on the student click, not on hidden provider retries, while those retries stay at three. Issue 25 asked for that decision before hidden work grows. Option 1 is the current behaviour and is the one I am locking in.

## Scope

- `reserveGenerate` still spends one daily quota unit per student generate.
- Hidden retries increment `usage.upstreamAttempts` only.
- `MAX_UPSTREAM_ATTEMPTS` stays 3 even when empty/validation retry env vars are higher.
- Teacher dashboard copy is `${used} of ${limit} used today (hidden retries included)`.
- Tests prove a two-attempt generate still leaves daily quota at 1, and a flood of invalid output stops at three upstream calls.

## Tradeoffs

Option 2 (each hidden call costs quota) would punish a student whose first programme is invalid. Option 3 (hybrid) needs a second meter. I did not add admin charts for `oracleMisses` / `upstreamAttempts`. Those counters already exist on `usage-store`.

## Blast Radius

Teachers see that retries are included in the daily number. Students keep one reservation per Generate click. A later agentic loop cannot raise the hidden cap without breaking the new tests.

## Verification

- `node --test apps/backend/src/rate-limit.test.mjs apps/backend/src/teacher-portal.test.mjs` 23 passed.

Closes #25
