### PR TITLE
feat(makecode): add pinned headless pxt decompiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ artifacts/
 node_modules/
 output/playwright/
 output/model-evals/
+output/makecode-cache/
 .DS_Store
 .env.audit
 .env.audit.local

--- a/apps/backend/src/runtime.mjs
+++ b/apps/backend/src/runtime.mjs
@@ -29,6 +29,7 @@ import {
 } from "./provider-registry.mjs";
 import { createRateLimitController } from "./rate-limit.mjs";
 import { createUsageStore } from "./usage-store.mjs";
+import { compileAndDecompile } from "../../../shared/makecode-decompile.mjs";
 
 const DEFAULT_FEEDBACK = "Model completed generation without explicit feedback notes.";
 const SUPPORTED_PROVIDERS = ["openai", "gemini", "openrouter", "opencode"];
@@ -689,6 +690,7 @@ async function generateManaged(
     emptyRetries: runtimeConfig.emptyRetries || 0,
     validationRetries: runtimeConfig.validationRetries || 0,
     maxAttempts,
+    runDecompile: (code, loopTarget) => compileAndDecompile({ code, target: loopTarget }),
     callModel: async (messages) => {
       if (providerCalls >= maxAttempts) {
         throw new Error("Upstream attempt limit reached");

--- a/docs/makecode-model-evaluation.md
+++ b/docs/makecode-model-evaluation.md
@@ -7,7 +7,7 @@ The model sampler and corpus are available now:
 - `evals/makecode-models/corpus.json`: 24 cases across micro:bit, Arcade, and Maker and across eight task categories. Micro:bit is the primary screening target; Arcade and Maker remain cross-target regression checks.
 - `evals/makecode-models/run.mjs`: exact Vibbit prompt construction, OpenAI-compatible sampling, strict contract checks, compatibility prechecks, prompt criteria, latency, token usage, and cost capture.
 
-The sampler deliberately awards only 40 provisional points. A regex cannot establish whether an API exists or code decompiles. The remaining 60 points require a pinned MakeCode compiler/decompiler runner described below.
+The sampler awards 40 contract and prefilter points in `results.jsonl`. A regex cannot establish whether an API exists or code decompiles. The remaining 60 points come from the pinned MakeCode compiler and decompiler in `shared/makecode-decompile.mjs`. Those scores are written to `makecode-validation.jsonl` beside the raw JSONL. The raw file stays immutable.
 
 ## What is being compared
 
@@ -39,7 +39,7 @@ There is one case per category per target:
 7. unsupported or invented APIs;
 8. valid-looking TypeScript constructs that compile in ordinary TypeScript but do not become native Blocks.
 
-Each case has conservative required and forbidden patterns. They test explicit semantics such as exact pins, timing, event kinds, and prohibited behavior. They are not an oracle: equivalent code can miss a textual pattern, and matching every pattern does not prove correctness. Any pattern change is a corpus-version change and should be reviewed against known-good target output.
+Each case has conservative required and forbidden patterns. They test explicit semantics such as exact pins, timing, event kinds, and prohibited behaviour. They are not an oracle: equivalent code can miss a textual pattern, and matching every pattern does not prove correctness. Any pattern change is a corpus-version change and should be reviewed against known-good target output.
 
 ### Target constraints
 
@@ -73,7 +73,7 @@ A **hard pass** requires all of the following, regardless of weighted score:
 - successful decompilation;
 - zero grey/TypeScript-statement blocks;
 - all required and forbidden case criteria;
-- for repair cases, the reported bad construct is absent and intended behavior remains.
+- for repair cases, the reported bad construct is absent and intended behaviour remains.
 
 Report:
 
@@ -161,28 +161,31 @@ node evals/makecode-models/run.mjs \
 
 Results go to ignored `output/model-evals/<provider>-<timestamp>/`:
 
-- `results.jsonl`: raw output, parsed output, provisional checks, usage/cost, and a null `makeCodeValidation` slot;
+- `results.jsonl`: raw output, parsed output, provisional checks, usage/cost, and a null `makeCodeValidation` slot that stays null;
+- `makecode-validation.jsonl`: pinned compile, decompile, grey-block, hash, and 60-point score records derived from that run;
 - `models-snapshot.json`: provider model metadata at run time;
 - `summary.json`: run configuration and counts.
+
+`--dry-run` still validates the matrix without API calls and without loading a compiler worker.
 
 Secrets are read only from the named environment variable and are never written. OpenRouter currently returns native token accounting and cost in `usage`; for endpoints that omit billed cost, retain token counts and apply a frozen price snapshot during analysis rather than silently using today's price later.
 
 ## True MakeCode validation
 
-### Preferred repeatable infrastructure
+The eval runner now calls `compileAndDecompile` from `shared/makecode-decompile.mjs` after each successful sample. That module loads a pinned `pxtworker.js` and `target.json` from `https://cdn.makecode.com/commit/<sha>/` for micro:bit, Arcade, and Maker. Pins live in `shared/makecode-pins.json`.
 
-Build a separate validator image or CI job with immutable editor/target versions. For each JSONL response:
+For each JSONL response with code:
 
-1. Create an isolated target project with `main.ts`, `main.blocks`, target-specific `pxt.json`, and pinned `mkc.json`.
-2. Compile Static TypeScript with `mkc build -j --no-colors` (Maker also specifies the Circuit Playground Express hardware variant). Require exit 0, `Build OK`, and no error diagnostics.
-3. Load the same pinned target compiler worker and obtain target compile options.
-4. Set `main.ts`, add `main.blocks`, set `ast = true` and `errorOnGreyBlocks = true`, then call the compiler worker operation `decompile` for `main.ts`.
-5. Require `result.success`, no error diagnostics, and non-empty `outfiles["main.blocks"]`.
-6. Independently reject XML containing `<block type="typescript_statement">`.
-7. Load/recompile the emitted Blocks and record round-trip diagnostics.
-8. Write target/PXT release IDs, diagnostics, output hashes, and grey-block count into `makeCodeValidation` in a derived result file; keep the raw JSONL immutable.
+1. Build an isolated in-memory project with `main.ts`, `main.blocks`, and target-specific `pxt.json`. Maker also sets the Circuit Playground Express hardware variant.
+2. Compile through the pinned worker. Require `success` and no error diagnostics.
+3. Decompile `main.ts` with `ast = true` and `errorOnGreyBlocks = true`. Require `success`, no error diagnostics, and non-empty `outfiles["main.blocks"]`.
+4. Independently reject XML containing `<block type="typescript_statement">`.
+5. Recompile the emitted Blocks when the decompile step succeeded, and record `roundTripOk`. If that step throws, store `null` and award no round-trip points.
+6. Write target/PXT release IDs, diagnostics, output hashes, and grey-block count into `makecode-validation.jsonl`. Leave `results.jsonl` unchanged.
 
-`mkc build` alone is insufficient: it tests compilation but has no decompile command. The decompile operation is the same target compiler path used when the MakeCode editor switches JavaScript back to Blocks. Pin `mkc.json.targetWebsite` to an immutable version or SHA-indexed target build, not stable/beta URLs; pin package dependencies and the Maker hardware variant too.
+`mkc build` alone is insufficient: it tests compilation but has no decompile command. Do not point `mkc.json.targetWebsite` at a live origin without a trailing slash. The SHA-indexed CDN worker is the pin.
+
+Managed generation uses the same module inside `runGenerationLoop` via `runDecompile`. The extension and BYOK routes omit that callback, so they still use the student-visible Blockly probe after paste.
 
 ### Browser validation
 
@@ -192,7 +195,7 @@ Where direct compiler-worker integration is unavailable, Playwright can load eac
 - `https://arcade.makecode.com/`;
 - `https://maker.makecode.com/` with the pinned board.
 
-The existing `npm run audit:smoke` is not this validation. It visits only micro:bit, stubs Monaco/provider calls, and accepts a log saying the decompile probe passed, failed, or was unavailable. The live audit also stubs Monaco and tests only one prompt. Neither currently compiles/decompiles the corpus for all targets.
+The existing `npm run audit:smoke` is not this validation. It visits only micro:bit, stubs Monaco/provider calls, and accepts a log saying the decompile probe passed, failed, or was unavailable. The live audit also stubs Monaco and tests only one prompt. Corpus compile and decompile run through `evals/makecode-models/run.mjs` and `shared/makecode-decompile.mjs`.
 
 ## What is automated now vs. deferred
 
@@ -203,18 +206,13 @@ Automated now:
 - strict raw JSON and permissive production parser outcomes;
 - Vibbit compatibility prefilter and case criteria;
 - repeated, interleaved sampling for OpenRouter and chat-compatible OpenCode Go/Zen models;
-- latency, resolved model, token usage, provider cost where supplied, prompt hashes, and model metadata snapshots.
+- latency, resolved model, token usage, provider cost where supplied, prompt hashes, and model metadata snapshots;
+- pinned target compile and TypeScript-to-Blocks decompile through `shared/makecode-decompile.mjs`;
+- grey-block/`typescript_statement` rejection and optional Blocks round-trip compilation.
 
-Requires pinned MakeCode infrastructure:
+Still deferred:
 
-- authoritative target API/type checking;
-- target compilation;
-- TypeScript-to-Blocks decompilation;
-- grey-block/`typescript_statement` rejection;
-- Blocks round-trip compilation;
-- visual/browser confirmation of conversion-dialog behavior and Vibbit's retry/fallback policy.
-
-Until that second stage exists, the suite is suitable for corpus review and inexpensive model screening, not a final model-selection claim.
+- visual/browser confirmation of conversion-dialog behaviour and Vibbit's retry/fallback policy on the live editors.
 
 ## Sources
 

--- a/evals/makecode-models/run.mjs
+++ b/evals/makecode-models/run.mjs
@@ -11,6 +11,10 @@ import {
   parseModelOutput,
   validateBlocksCompatibility
 } from "../../shared/makecode-compat-core.mjs";
+import {
+  compileAndDecompile,
+  scoreMakeCodeValidation
+} from "../../shared/makecode-decompile.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../..");
@@ -152,9 +156,38 @@ function provisionalScore(contract, compatibility, criteria) {
   const criteriaPoints = criteria.total ? 20 * criteria.passed / criteria.total : 20;
   return {
     score: Number((contractPoints + compatibilityPoints + criteriaPoints).toFixed(2)),
-    max: 40,
-    pendingMakeCodePoints: 60
+    max: 40
   };
+}
+
+function emptyMakeCodeValidation(message) {
+  return {
+    ok: false,
+    compileOk: false,
+    decompileOk: false,
+    nativeBlocks: false,
+    greyBlocks: 0,
+    snippets: [],
+    diagnostics: [{ messageText: message }],
+    targetRelease: null,
+    hashes: {},
+    roundTripOk: null,
+    reason: message
+  };
+}
+
+async function runPinnedMakeCodeValidation(code, target) {
+  if (!String(code || "").trim()) {
+    const report = emptyMakeCodeValidation("empty output");
+    return { report, score: scoreMakeCodeValidation(report), error: null };
+  }
+  try {
+    const report = await compileAndDecompile({ code, target });
+    return { report, score: scoreMakeCodeValidation(report), error: null };
+  } catch (error) {
+    const report = emptyMakeCodeValidation(error.message);
+    return { report, score: scoreMakeCodeValidation(report), error: error.message };
+  }
 }
 
 function buildPrompt(testCase, promptMode) {
@@ -293,6 +326,7 @@ async function main() {
   await writeFile(path.join(runDir, "models-snapshot.json"), JSON.stringify(modelSnapshot, null, 2) + "\n");
 
   const records = [];
+  const validationRecords = [];
   for (let index = 0; index < matrix.length; index += 1) {
     const { model, testCase, repetition } = matrix[index];
     const { system, user } = buildPrompt(testCase, options.promptMode);
@@ -370,15 +404,45 @@ async function main() {
         makeCodeValidation: null
       };
       records.push(record);
-      console.log(`${provisional.score}/${provisional.max}, ${latencyMs}ms`);
+      const pinned = await runPinnedMakeCodeValidation(parsed.code, testCase.target);
+      validationRecords.push({
+        requestedModel: model,
+        caseId: testCase.id,
+        repetition,
+        target: testCase.target,
+        targetBoard: testCase.targetBoard || null,
+        makeCodeValidation: pinned.report,
+        makeCodeScore: pinned.score,
+        totalScore: Number((provisional.score + pinned.score.score).toFixed(2)),
+        totalMax: 100,
+        error: pinned.error
+      });
+      console.log(`${provisional.score}/${provisional.max} + ${pinned.score.score}/${pinned.score.max}, ${latencyMs}ms`);
     } catch (error) {
       records.push({ ...base, status: "error", error: error.message, makeCodeValidation: null });
+      validationRecords.push({
+        requestedModel: model,
+        caseId: testCase.id,
+        repetition,
+        target: testCase.target,
+        makeCodeValidation: null,
+        makeCodeScore: { score: 0, max: 60 },
+        totalScore: 0,
+        totalMax: 100,
+        error: error.message
+      });
       console.log(`ERROR ${error.message}`);
     }
   }
 
   const resultsPath = path.join(runDir, "results.jsonl");
   await writeFile(resultsPath, records.map((item) => JSON.stringify(item)).join("\n") + "\n");
+  const validationPath = path.join(runDir, "makecode-validation.jsonl");
+  await writeFile(validationPath, validationRecords.map((item) => JSON.stringify(item)).join("\n") + "\n");
+  const scored = validationRecords.filter((item) => item.makeCodeValidation);
+  const meanTotal = scored.length
+    ? Number((scored.reduce((sum, item) => sum + item.totalScore, 0) / scored.length).toFixed(2))
+    : null;
   const summary = {
     schemaVersion: 1,
     createdAt: new Date().toISOString(),
@@ -395,8 +459,10 @@ async function main() {
     requests: records.length,
     successfulRequests: records.filter((item) => item.status === "ok").length,
     errors: records.filter((item) => item.status === "error").length,
-    note: "Scores are provisional (40 points maximum) until pinned MakeCode compile/decompile validation fills makeCodeValidation.",
+    meanTotalScore: meanTotal,
+    note: "results.jsonl is the immutable provider capture. Pinned compile and decompile scores live in makecode-validation.jsonl.",
     results: "results.jsonl",
+    makeCodeValidation: "makecode-validation.jsonl",
     modelSnapshot: "models-snapshot.json"
   };
   await writeFile(path.join(runDir, "summary.json"), JSON.stringify(summary, null, 2) + "\n");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,49 @@
 {
   "name": "vibbit-extension",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibbit-extension",
-      "version": "0.2.0",
+      "version": "0.2.3",
+      "dependencies": {
+        "makecode": "^1.3.5"
+      },
       "devDependencies": {
         "canvas": "^3.2.1",
         "playwright": "^1.58.2"
       }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -43,6 +76,16 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/buffer": {
@@ -85,12 +128,61 @@
         "node": "^18.12.0 || >= 20.9.0"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -155,6 +247,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -177,6 +275,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -198,11 +326,21 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -211,6 +349,40 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/makecode": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/makecode/-/makecode-1.3.5.tgz",
+      "integrity": "sha512-vTiW40nzM9w1mCLfIxf+oCgj0wOqvbqrUOmrePUdeT8MEUnYSBSTIwszd80UyNCKj3BYpOJrBLSEsGBXM90z/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^8.2.0",
+        "glob": "^7.2.0",
+        "makecode-core": "^1.7.3",
+        "node-watch": "^0.7.2",
+        "semver": "^7.3.7"
+      },
+      "bin": {
+        "makecode": "makecode",
+        "mkc": "makecode"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/makecode-core": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/makecode-core/-/makecode-core-1.7.9.tgz",
+      "integrity": "sha512-v0SHOexYP74QkxP3BUTyC7edUy5C1lk8h9C/3f9NDzz5RuDqwOJhKSEWAeoP0nV0yPbILbHtaQK67lZAjsaZvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.8",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -223,6 +395,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -269,14 +453,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-watch": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+      "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/playwright": {
@@ -405,7 +606,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -481,6 +681,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -535,7 +747,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "audit:live": "node scripts/audit/live.mjs",
     "audit:install": "npx playwright install chromium"
   },
+  "dependencies": {
+    "makecode": "^1.3.5"
+  },
   "devDependencies": {
     "canvas": "^3.2.1",
     "playwright": "^1.58.2"

--- a/shared/makecode-compat-core.mjs
+++ b/shared/makecode-compat-core.mjs
@@ -1252,7 +1252,8 @@ export function buildFailedAttemptUserTurn({
   validation,
   target,
   kind,
-  strict = false
+  strict = false,
+  decompile = null
 } = {}) {
   const failedProgramme = code == null ? "" : String(code);
   const lines = [
@@ -1262,6 +1263,12 @@ export function buildFailedAttemptUserTurn({
   ];
   if (kind === "empty") {
     lines.push("Your previous reply had empty code. Return a complete MakeCode programme as JSON only.");
+  } else if (kind === "decompile") {
+    lines.push(buildDecompileFixRequest({
+      greyBlocks: decompile && decompile.greyBlocks,
+      snippets: decompile && decompile.snippets,
+      reason: (decompile && decompile.reason) || "MakeCode decompile produced grey blocks."
+    }));
   } else {
     const violations = validation && Array.isArray(validation.violations) ? validation.violations : [];
     lines.push(buildCorrectionInstruction(violations, target, { strict: Boolean(strict) }));
@@ -1322,7 +1329,8 @@ export async function runGenerationLoop({
   emptyRetries = 0,
   validationRetries = 0,
   maxAttempts = 1,
-  callModel
+  callModel,
+  runDecompile
 } = {}) {
   const attemptLimit = Math.max(1, Math.trunc(Number(maxAttempts) || 1));
   let emptyLeft = Math.max(0, Math.trunc(Number(emptyRetries) || 0));
@@ -1342,15 +1350,26 @@ export async function runGenerationLoop({
     const code = sanitizeMakeCode(parsed.code);
     const validation = runValidateBlocks(code, target);
     // Empty source can pass the static validator; treat it as empty, not ok.
-    const reason = !String(code || "").trim()
+    let reason = !String(code || "").trim()
       ? "empty"
       : (validation.ok ? "ok" : "invalid");
+    let decompile = null;
+    if (reason === "ok" && typeof runDecompile === "function") {
+      try {
+        decompile = await runDecompile(code, target);
+        if (decompile && decompile.ok === false) reason = "decompile";
+      } catch {
+        // Worker outage must not stub every Managed generate.
+        decompile = { skipped: true };
+      }
+    }
     last = {
       raw: raw == null ? "" : String(raw),
       code,
       feedback: parsed.feedback,
       validation,
-      reason
+      reason,
+      decompile
     };
     attempts.push(last);
 
@@ -1384,6 +1403,19 @@ export async function runGenerationLoop({
       continue;
     }
 
+    if (reason === "decompile" && validationLeft > 0) {
+      validationLeft -= 1;
+      messages.push(transcriptTurn("assistant", code));
+      messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+        code,
+        validation,
+        target,
+        kind: "decompile",
+        decompile
+      })));
+      continue;
+    }
+
     break;
   }
 
@@ -1413,6 +1445,20 @@ export async function runGenerationLoop({
       validation: lastValidation,
       upstreamAttempts,
       outcome: "stub-empty",
+      attempts
+    };
+  }
+
+  if (last && last.reason === "decompile") {
+    const why = last.decompile && last.decompile.reason
+      ? last.decompile.reason
+      : "grey blocks after decompile";
+    return {
+      code: stubForTarget(target),
+      feedback: normaliseFeedback([...lastFeedback, "Validation fallback: " + why]),
+      validation: lastValidation,
+      upstreamAttempts,
+      outcome: "stub-invalid",
       attempts
     };
   }

--- a/shared/makecode-compat-core.test.mjs
+++ b/shared/makecode-compat-core.test.mjs
@@ -455,3 +455,80 @@ test("decompile fix request uses British spelling and names grey blocks", () => 
   assert.ok(text.includes("baz()"));
   assert.ok(!text.includes("dropped"));
 });
+
+test("generation loop retries a headless decompile miss using the same retry budget", async () => {
+  const calls = [];
+  let decompileCalls = 0;
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    runDecompile: async () => {
+      decompileCalls += 1;
+      if (decompileCalls === 1) {
+        return {
+          ok: false,
+          greyBlocks: 1,
+          snippets: ["grey()"],
+          reason: "Detected 1 grey JavaScript block(s)"
+        };
+      }
+      return { ok: true, greyBlocks: 0, snippets: [] };
+    },
+    callModel: async (messages) => {
+      calls.push(messages.slice());
+      return jsonOutput(VALID_HEART, ["heart"]);
+    }
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 2);
+  assert.equal(decompileCalls, 2);
+  assert.equal(result.code, VALID_HEART);
+  assert.ok(calls[1][3].content.includes("<<<FAILED_ATTEMPT>>>"));
+  assert.ok(calls[1][3].content.includes(VALID_HEART));
+  assert.ok(calls[1][3].content.includes("Grey block count: 1."));
+});
+
+test("generation loop fails open when the decompiler throws", async () => {
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 2,
+    validationRetries: 2,
+    maxAttempts: 3,
+    runDecompile: async () => {
+      throw new Error("cdn down");
+    },
+    callModel: async () => jsonOutput(VALID_HEART, ["ok"])
+  });
+  assert.equal(result.outcome, "ok");
+  assert.equal(result.upstreamAttempts, 1);
+  assert.equal(result.code, VALID_HEART);
+  assert.equal(result.attempts[0].decompile.skipped, true);
+});
+
+test("generation loop stubs after decompile retries are exhausted", async () => {
+  const result = await runGenerationLoop({
+    target: "microbit",
+    systemPrompt: "sys",
+    initialUserPrompt: "show a heart",
+    emptyRetries: 0,
+    validationRetries: 1,
+    maxAttempts: 2,
+    runDecompile: async () => ({
+      ok: false,
+      greyBlocks: 2,
+      snippets: ["oops()"],
+      reason: "Detected 2 grey JavaScript block(s)"
+    }),
+    callModel: async () => jsonOutput('basic.showIcon(IconNames.Heart)', ["ok"])
+  });
+  assert.equal(result.outcome, "stub-invalid");
+  assert.equal(result.upstreamAttempts, 2);
+  assert.equal(result.code, stubForTarget("microbit"));
+  assert.ok(result.feedback.some((line) => /grey/i.test(line)));
+});

--- a/shared/makecode-decompile.mjs
+++ b/shared/makecode-decompile.mjs
@@ -1,0 +1,284 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const PINS = JSON.parse(
+  readFileSync(new URL("./makecode-pins.json", import.meta.url), "utf8")
+);
+
+const CDN_ROOT = "https://cdn.makecode.com";
+const EMPTY_BLOCKS = '<xml xmlns="http://www.w3.org/1999/xhtml"></xml>';
+const DIAGNOSTIC_ERROR = 1;
+
+const services = new Map();
+let hostReady = false;
+let queue = Promise.resolve();
+
+function withLock(fn) {
+  const run = queue.then(fn, fn);
+  queue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(String(value || ""), "utf8").digest("hex");
+}
+
+function flattenMessage(messageText) {
+  if (typeof messageText === "string") return messageText;
+  if (messageText && typeof messageText.messageText === "string") {
+    return messageText.messageText;
+  }
+  return String(messageText || "");
+}
+
+function summariseDiagnostics(diagnostics) {
+  return (Array.isArray(diagnostics) ? diagnostics : []).map((item) => ({
+    code: item && item.code,
+    category: item && item.category,
+    messageText: flattenMessage(item && item.messageText),
+    line: item && item.line,
+    fileName: item && item.fileName
+  }));
+}
+
+function errorDiagnostics(diagnostics) {
+  return summariseDiagnostics(diagnostics).filter((item) => Number(item.category) === DIAGNOSTIC_ERROR);
+}
+
+export function getTargetPin(target) {
+  const pin = PINS[target];
+  if (!pin) throw new Error("Unknown MakeCode target: " + String(target));
+  return pin;
+}
+
+export function listPinnedTargets() {
+  return Object.keys(PINS);
+}
+
+export function countGreyBlocks(xml) {
+  const matches = String(xml || "").match(/type="typescript_statement"/g);
+  return matches ? matches.length : 0;
+}
+
+function decodeXmlAttr(text) {
+  return String(text || "")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+export function extractGreySnippets(xml) {
+  const snippets = [];
+  const source = String(xml || "");
+  const blockRe = /<block\b[^>]*\btype="typescript_statement"[^>]*>([\s\S]*?)<\/block>/gi;
+  let blockMatch;
+  while ((blockMatch = blockRe.exec(source)) && snippets.length < 8) {
+    const body = blockMatch[1] || "";
+    const lines = [];
+    const lineRe = /\bline(\d+)="([^"]*)"/g;
+    let lineMatch;
+    while ((lineMatch = lineRe.exec(body))) {
+      lines[Number(lineMatch[1])] = decodeXmlAttr(lineMatch[2]);
+    }
+    const preview = lines.filter((item) => item != null).join(" ").replace(/\s+/g, " ").trim();
+    snippets.push((preview || "grey block").slice(0, 140));
+  }
+  return snippets;
+}
+
+export function scoreMakeCodeValidation(report) {
+  const compile = report && report.compileOk ? 20 : 0;
+  const decompile = report && report.decompileOk ? 25 : 0;
+  const native = report && report.nativeBlocks ? 10 : 0;
+  const roundTrip = report && report.roundTripOk === true ? 5 : 0;
+  return {
+    compile,
+    decompile,
+    native,
+    roundTrip,
+    score: compile + decompile + native + roundTrip,
+    max: 60,
+    roundTripMeasured: Boolean(report) && report.roundTripOk !== null && report.roundTripOk !== undefined
+  };
+}
+
+function cacheRoot() {
+  return process.env.VIBBIT_MAKECODE_CACHE
+    || path.join(repoRoot, "output", "makecode-cache");
+}
+
+async function readCachedText(dest, url) {
+  if (existsSync(dest)) return readFile(dest, "utf8");
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("MakeCode CDN " + response.status + " for " + url);
+  const text = await response.text();
+  await mkdir(path.dirname(dest), { recursive: true });
+  const tmp = dest + "." + process.pid + ".tmp";
+  await writeFile(tmp, text);
+  await rename(tmp, dest);
+  return text;
+}
+
+function ensureHost() {
+  if (hostReady) return;
+  const require = createRequire(import.meta.url);
+  const { setHost } = require("makecode-core/built/host");
+  const { createNodeHost } = require("makecode/built/nodeHost");
+  setHost(createNodeHost());
+  hostReady = true;
+}
+
+async function serviceFor(target) {
+  const cached = services.get(target);
+  if (cached) return cached;
+  ensureHost();
+  const pin = getTargetPin(target);
+  const require = createRequire(import.meta.url);
+  const { NodeLanguageService } = require("makecode/built/languageService");
+  const cdn = CDN_ROOT + "/commit/" + pin.commit;
+  const dir = path.join(cacheRoot(), pin.commit);
+  const [pxtWorkerJs, targetJsonText] = await Promise.all([
+    readCachedText(path.join(dir, "pxtworker.js"), cdn + "/pxtworker.js"),
+    readCachedText(path.join(dir, "target.json"), cdn + "/target.json")
+  ]);
+  const targetJson = JSON.parse(targetJsonText);
+  const ls = new NodeLanguageService({
+    cache: {
+      getAsync: async () => null,
+      setAsync: async () => {}
+    },
+    versionNumber: 1,
+    cdnUrl: CDN_ROOT,
+    simUrl: "",
+    website: pin.website,
+    pxtWorkerJs,
+    targetJson,
+    webConfig: { cdnUrl: CDN_ROOT, pxtVersion: pin.pxtVersion, targetVersion: pin.targetVersion },
+    targetConfig: {}
+  });
+  await ls.registerDriverCallbacksAsync({
+    cacheGet: async () => null,
+    cacheSet: async () => {}
+  });
+  await ls.setWebConfigAsync({ cdnUrl: CDN_ROOT });
+  if (pin.hwVariant) await ls.setHwVariantAsync(pin.hwVariant);
+  const packed = { ls, pin, targetJson };
+  services.set(target, packed);
+  return packed;
+}
+
+function projectFiles(pin, code, blocksXml) {
+  return {
+    "pxt.json": JSON.stringify({
+      name: "vibbit-decompile",
+      dependencies: pin.dependencies,
+      files: ["main.ts", "main.blocks"]
+    }),
+    "main.ts": String(code || ""),
+    "main.blocks": blocksXml || EMPTY_BLOCKS
+  };
+}
+
+async function compileOptions(ls, pin, files) {
+  const opts = await ls.getCompileOptionsAsync(
+    {
+      files,
+      mkcConfig: pin.hwVariant ? { hwVariant: pin.hwVariant } : {},
+      config: {}
+    },
+    { native: false }
+  );
+  opts.ast = true;
+  opts.errorOnGreyBlocks = true;
+  opts.fileSystem = opts.fileSystem || {};
+  opts.fileSystem["main.ts"] = files["main.ts"];
+  opts.fileSystem["main.blocks"] = files["main.blocks"];
+  return opts;
+}
+
+function failReason({ compileOk, decompileOk, greyBlocks, blocksXml }) {
+  if (!compileOk) return "Pinned MakeCode compile failed.";
+  if (!decompileOk) return "Pinned MakeCode decompile failed.";
+  if (!String(blocksXml || "").trim()) return "Decompiler returned empty main.blocks.";
+  if (greyBlocks > 0) return "Detected " + greyBlocks + " grey JavaScript block(s)";
+  return "MakeCode validation failed.";
+}
+
+async function compileAndDecompileUnlocked({ code, target }) {
+  const { ls, pin } = await serviceFor(target);
+  const files = projectFiles(pin, code, EMPTY_BLOCKS);
+  await ls.setProjectTextAsync(files);
+  const opts = await compileOptions(ls, pin, files);
+  const compile = ls.performOperationAsync("compile", { options: opts });
+  const decompile = ls.performOperationAsync("decompile", { options: opts, fileName: "main.ts" });
+  const blocksXml = decompile && decompile.outfiles && decompile.outfiles["main.blocks"]
+    ? String(decompile.outfiles["main.blocks"])
+    : "";
+  const compileDiagnostics = summariseDiagnostics(compile && compile.diagnostics);
+  const decompileDiagnostics = summariseDiagnostics(decompile && decompile.diagnostics);
+  const compileOk = Boolean(compile && compile.success) && errorDiagnostics(compile && compile.diagnostics).length === 0;
+  const decompileOk = Boolean(decompile && decompile.success)
+    && errorDiagnostics(decompile && decompile.diagnostics).length === 0
+    && Boolean(blocksXml.trim());
+  const greyBlocks = countGreyBlocks(blocksXml);
+  const nativeBlocks = Boolean(blocksXml.trim()) && greyBlocks === 0;
+  const snippets = extractGreySnippets(blocksXml);
+  const compileJs = compile && compile.outfiles
+    ? (compile.outfiles["binary.js"] || compile.outfiles["binary.asm"] || "")
+    : "";
+
+  let roundTripOk = null;
+  if (decompileOk && blocksXml) {
+    try {
+      const roundFiles = projectFiles(pin, code, blocksXml);
+      await ls.setProjectTextAsync(roundFiles);
+      const roundOpts = await compileOptions(ls, pin, roundFiles);
+      const roundCompile = ls.performOperationAsync("compile", { options: roundOpts });
+      roundTripOk = Boolean(roundCompile && roundCompile.success)
+        && errorDiagnostics(roundCompile && roundCompile.diagnostics).length === 0;
+    } catch {
+      roundTripOk = null;
+    }
+  }
+
+  const ok = compileOk && decompileOk && nativeBlocks;
+  const targetRelease = {
+    target,
+    commit: pin.commit,
+    targetVersion: pin.targetVersion,
+    pxtVersion: pin.pxtVersion,
+    hwVariant: pin.hwVariant,
+    website: pin.website
+  };
+  return {
+    ok,
+    compileOk,
+    decompileOk,
+    nativeBlocks,
+    greyBlocks,
+    snippets,
+    diagnostics: [...compileDiagnostics, ...decompileDiagnostics],
+    targetRelease,
+    blocksXml,
+    hashes: {
+      blocksSha256: blocksXml ? sha256(blocksXml) : null,
+      compileJsSha256: compileJs ? sha256(compileJs) : null
+    },
+    roundTripOk,
+    reason: ok ? "" : failReason({ compileOk, decompileOk, greyBlocks, blocksXml })
+  };
+}
+
+export function compileAndDecompile(input) {
+  return withLock(() => compileAndDecompileUnlocked(input));
+}

--- a/shared/makecode-decompile.mjs
+++ b/shared/makecode-decompile.mjs
@@ -14,6 +14,7 @@ const PINS = JSON.parse(
 const CDN_ROOT = "https://cdn.makecode.com";
 const EMPTY_BLOCKS = '<xml xmlns="http://www.w3.org/1999/xhtml"></xml>';
 const DIAGNOSTIC_ERROR = 1;
+const nativeFetch = globalThis.fetch.bind(globalThis);
 
 const services = new Map();
 let hostReady = false;
@@ -119,7 +120,7 @@ function cacheRoot() {
 
 async function readCachedText(dest, url) {
   if (existsSync(dest)) return readFile(dest, "utf8");
-  const response = await fetch(url);
+  const response = await nativeFetch(url);
   if (!response.ok) throw new Error("MakeCode CDN " + response.status + " for " + url);
   const text = await response.text();
   await mkdir(path.dirname(dest), { recursive: true });

--- a/shared/makecode-decompile.test.mjs
+++ b/shared/makecode-decompile.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  compileAndDecompile,
+  countGreyBlocks,
+  extractGreySnippets,
+  getTargetPin,
+  listPinnedTargets,
+  scoreMakeCodeValidation
+} from "./makecode-decompile.mjs";
+
+const LIVE_MS = 180000;
+
+test("compat-core does not import the Node decompiler", async () => {
+  const source = await readFile(new URL("./makecode-compat-core.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /makecode-decompile/);
+  assert.doesNotMatch(source, /pxtworker/);
+});
+
+test("generated work.js does not embed the pxt worker", async () => {
+  const source = await readFile(new URL("../work.js", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /pxtworker\.js/);
+  assert.doesNotMatch(source, /makecode-decompile/);
+});
+
+test("pin table covers microbit, arcade, and maker with SHA commits", () => {
+  assert.deepEqual(listPinnedTargets(), ["microbit", "arcade", "maker"]);
+  for (const target of listPinnedTargets()) {
+    const pin = getTargetPin(target);
+    assert.match(pin.commit, /^[0-9a-f]{40}$/);
+    assert.ok(pin.website.startsWith("https://"));
+    assert.ok(pin.dependencies && Object.keys(pin.dependencies).length > 0);
+  }
+  assert.equal(getTargetPin("maker").hwVariant, "adafruit-circuit-playground-express");
+  assert.throws(() => getTargetPin("unknown"), /Unknown MakeCode target/);
+});
+
+test("XML reject counts typescript_statement independently of decompile.success", () => {
+  const xml = [
+    '<xml xmlns="http://www.w3.org/1999/xhtml">',
+    '<block type="pxt-on-start"></block>',
+    '<block type="typescript_statement">',
+    '<mutation line0="class Foo &#123;&#125;" numlines="1"></mutation>',
+    "</block>",
+    "</xml>"
+  ].join("");
+  assert.equal(countGreyBlocks(xml), 1);
+  assert.deepEqual(extractGreySnippets(xml), ["class Foo {}"]);
+});
+
+test("MakeCode score awards 60 only when compile, decompile, native, and round-trip pass", () => {
+  const perfect = scoreMakeCodeValidation({
+    compileOk: true,
+    decompileOk: true,
+    nativeBlocks: true,
+    roundTripOk: true
+  });
+  assert.equal(perfect.score, 60);
+  assert.equal(perfect.max, 60);
+
+  const noRoundTrip = scoreMakeCodeValidation({
+    compileOk: true,
+    decompileOk: true,
+    nativeBlocks: true,
+    roundTripOk: null
+  });
+  assert.equal(noRoundTrip.score, 55);
+  assert.equal(noRoundTrip.roundTrip, 0);
+
+  const grey = scoreMakeCodeValidation({
+    compileOk: true,
+    decompileOk: true,
+    nativeBlocks: false,
+    roundTripOk: false
+  });
+  assert.equal(grey.score, 45);
+});
+
+test("pinned workers compile and decompile native stubs", { timeout: LIVE_MS }, async () => {
+  const cases = [
+    { target: "microbit", code: 'basic.showString("Hi")\n', nativeHint: /pxt-on-start|device_print_message/ },
+    { target: "arcade", code: 'game.splash("Hi")\n', nativeHint: /<block/ },
+    { target: "maker", code: "forever(function () {\n})\n", nativeHint: /<block/ }
+  ];
+  for (const item of cases) {
+    const report = await compileAndDecompile({ target: item.target, code: item.code });
+    assert.equal(report.compileOk, true, item.target + " compile " + JSON.stringify(report.diagnostics.slice(0, 3)));
+    assert.equal(report.decompileOk, true, item.target + " decompile");
+    assert.equal(report.greyBlocks, 0, item.target + " grey");
+    assert.equal(report.nativeBlocks, true, item.target + " native");
+    assert.equal(report.ok, true, item.target + " ok");
+    assert.match(report.blocksXml, item.nativeHint);
+    assert.equal(report.targetRelease.commit, getTargetPin(item.target).commit);
+    assert.match(report.hashes.blocksSha256, /^[0-9a-f]{64}$/);
+  }
+});
+
+test("class Foo decompiles to grey typescript_statement blocks", { timeout: LIVE_MS }, async () => {
+  const report = await compileAndDecompile({ target: "microbit", code: "class Foo {}\n" });
+  assert.equal(report.ok, false);
+  assert.equal(report.nativeBlocks, false);
+  assert.ok(report.greyBlocks > 0, "grey count " + report.greyBlocks);
+  assert.match(report.blocksXml, /typescript_statement/);
+  assert.ok(report.snippets.some((item) => item.includes("class Foo")));
+});

--- a/shared/makecode-pins.json
+++ b/shared/makecode-pins.json
@@ -1,0 +1,34 @@
+{
+  "microbit": {
+    "website": "https://makecode.microbit.org/",
+    "commit": "a2de741814d32e5156dd57569b9229adbfdb07d6",
+    "targetVersion": "9.0.12",
+    "pxtVersion": "13.0.9",
+    "dependencies": {
+      "core": "*",
+      "radio": "*",
+      "microphone": "*"
+    },
+    "hwVariant": null
+  },
+  "arcade": {
+    "website": "https://arcade.makecode.com/",
+    "commit": "bff6e9502e84eb1df55cd6f695b214eefabc20e7",
+    "targetVersion": "4.0.14",
+    "pxtVersion": "12.2.34",
+    "dependencies": {
+      "device": "*"
+    },
+    "hwVariant": null
+  },
+  "maker": {
+    "website": "https://maker.makecode.com/",
+    "commit": "4301981bb21b375f5c827867187dc806b9eb67ec",
+    "targetVersion": "0.15.77",
+    "pxtVersion": "13.1.5",
+    "dependencies": {
+      "adafruit-circuit-playground-express": "*"
+    },
+    "hwVariant": "adafruit-circuit-playground-express"
+  }
+}

--- a/work.js
+++ b/work.js
@@ -3311,7 +3311,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       validation,
       target,
       kind,
-      strict = false
+      strict = false,
+      decompile = null
     } = {}) {
       const failedProgramme = code == null ? "" : String(code);
       const lines = [
@@ -3321,6 +3322,12 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       ];
       if (kind === "empty") {
         lines.push("Your previous reply had empty code. Return a complete MakeCode programme as JSON only.");
+      } else if (kind === "decompile") {
+        lines.push(buildDecompileFixRequest({
+          greyBlocks: decompile && decompile.greyBlocks,
+          snippets: decompile && decompile.snippets,
+          reason: (decompile && decompile.reason) || "MakeCode decompile produced grey blocks."
+        }));
       } else {
         const violations = validation && Array.isArray(validation.violations) ? validation.violations : [];
         lines.push(buildCorrectionInstruction(violations, target, { strict: Boolean(strict) }));
@@ -3381,7 +3388,8 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
       emptyRetries = 0,
       validationRetries = 0,
       maxAttempts = 1,
-      callModel
+      callModel,
+      runDecompile
     } = {}) {
       const attemptLimit = Math.max(1, Math.trunc(Number(maxAttempts) || 1));
       let emptyLeft = Math.max(0, Math.trunc(Number(emptyRetries) || 0));
@@ -3401,15 +3409,26 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
         const code = sanitizeMakeCode(parsed.code);
         const validation = runValidateBlocks(code, target);
         // Empty source can pass the static validator; treat it as empty, not ok.
-        const reason = !String(code || "").trim()
+        let reason = !String(code || "").trim()
           ? "empty"
           : (validation.ok ? "ok" : "invalid");
+        let decompile = null;
+        if (reason === "ok" && typeof runDecompile === "function") {
+          try {
+            decompile = await runDecompile(code, target);
+            if (decompile && decompile.ok === false) reason = "decompile";
+          } catch {
+            // Worker outage must not stub every Managed generate.
+            decompile = { skipped: true };
+          }
+        }
         last = {
           raw: raw == null ? "" : String(raw),
           code,
           feedback: parsed.feedback,
           validation,
-          reason
+          reason,
+          decompile
         };
         attempts.push(last);
 
@@ -3443,6 +3462,19 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
           continue;
         }
 
+        if (reason === "decompile" && validationLeft > 0) {
+          validationLeft -= 1;
+          messages.push(transcriptTurn("assistant", code));
+          messages.push(transcriptTurn("user", buildFailedAttemptUserTurn({
+            code,
+            validation,
+            target,
+            kind: "decompile",
+            decompile
+          })));
+          continue;
+        }
+
         break;
       }
 
@@ -3472,6 +3504,20 @@ const APP_TOKEN = ""; // set only if your server enforces SERVER_APP_TOKEN
           validation: lastValidation,
           upstreamAttempts,
           outcome: "stub-empty",
+          attempts
+        };
+      }
+
+      if (last && last.reason === "decompile") {
+        const why = last.decompile && last.decompile.reason
+          ? last.decompile.reason
+          : "grey blocks after decompile";
+        return {
+          code: stubForTarget(target),
+          feedback: normaliseFeedback([...lastFeedback, "Validation fallback: " + why]),
+          validation: lastValidation,
+          upstreamAttempts,
+          outcome: "stub-invalid",
           attempts
         };
       }


### PR DESCRIPTION
## Why

Hidden retries could only use the static regex oracle. Students still saw grey `typescript_statement` blocks, and model evals stopped at a 40-point provisional score with `makeCodeValidation` left null.

A pinned headless pxt worker is the same decompile path MakeCode uses when switching JavaScript to Blocks. Both Managed generation and the eval runner can call it without pasting into a student editor.

## Scope

- Adds `shared/makecode-pins.json` with SHA-indexed CDN commits for micro:bit, Arcade, and Maker (Circuit Playground Express).
- Adds Node-only `shared/makecode-decompile.mjs` `compileAndDecompile`. It loads cached `pxtworker.js` and `target.json` from `https://cdn.makecode.com/commit/<sha>/`.
- `runGenerationLoop` takes optional `runDecompile`. Managed `generateManaged` passes it. BYOK and the extension omit it, so they still use the student-visible Blockly probe after paste.
- Decompile misses consume the existing validation retry budget and `buildDecompileFixRequest`. Worker throws fail open. Exhausted retries still stub.
- Evals write scores to derived `makecode-validation.jsonl`. `results.jsonl` keeps `makeCodeValidation: null`.
- `work.js` is regenerated. It must not import the worker. A test encodes that.

Closes #23. Closes #22.

## Tradeoffs

I did not wrap `mkc build`. A live `makecode.microbit.org` download without a trailing slash fails DNS, and `mkc` has no decompile command.

One PR owns both issues. Two writers on the same worker would drift.

Round-trip recompiles the original TypeScript together with the emitted Blocks. That is weaker than a Blocks-only recompile. Legal stubs scored a full 60 points including `roundTripOk: true` on this pin set.

## Blast Radius

Students on Managed no longer need a grey Blocks view before a hidden retry can see the miss. First Managed generate in a process fetches three worker bundles (then caches under `output/makecode-cache/`).

Maintainers inherit a Node dependency on `makecode`. Do not import `shared/makecode-decompile.mjs` from `shared/makecode-compat-core.mjs` or it will be copied into the extension.

## Verification

- Live worker. `basic.showString("Hi")`, `game.splash("Hi")`, and Maker `forever` compiled and decompiled with zero grey blocks. `class Foo {}` compiled and decompiled to one `typescript_statement` (diagnostic 1001).
- `node --test shared/makecode-compat-core.test.mjs shared/makecode-decompile.test.mjs` 35 passed.
- `node --test shared/*.test.mjs apps/backend/src/*.test.mjs` 174 passed.
- `npm run check:compat-core` in sync.
- `node evals/makecode-models/run.mjs --provider openrouter --models openai/gpt-5.6-luna --target microbit --samples 1 --dry-run` still skips the worker.